### PR TITLE
Add makedocs again to docs/make.jl

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,5 +1,11 @@
 using Documenter, ConstrainedDFO
 
+makedocs(
+    sitename="ConstrainedDFO.jl",
+    remotes = nothing,
+    modules = [ConstrainedDFO]
+)
+
 deploydocs(
-    repo = "github.com/sblelong/ConstrainedDFO.jl.git"
+    repo = "github.com/sblelong/ConstrainedDFO.jl.git",
 )

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,8 +2,6 @@ using Documenter, ConstrainedDFO
 
 makedocs(
     sitename="ConstrainedDFO.jl",
-    remotes = nothing,
-    modules = [ConstrainedDFO]
 )
 
 deploydocs(


### PR DESCRIPTION
Yes, you read the docs too fast and *replaced* `makedocs()` by `deploydocs()` instead of adding it.