### PR TITLE
Invertibility hierarchy

### DIFF
--- a/src/ConstrainedDFO.jl
+++ b/src/ConstrainedDFO.jl
@@ -52,6 +52,7 @@ export AbstractInvertibilityBound,
     EqualityManifold
 include("types/invertibility.jl")
 export AbstractInvertibilityBound,
+    ExactInvertibility,
     NOverSqrtSpectral,
     NOverSpectral,
     OneOverSqrtSpectral,

--- a/src/ConstrainedDFO.jl
+++ b/src/ConstrainedDFO.jl
@@ -49,14 +49,15 @@ using ResumableFunctions
 # Riemannian submanifolds of ℝ^n defined as feasible sets for equality constraints
 include("types/EqualityManifold.jl")
 export AbstractInvertibilityBound,
-    EqualityManifold,
-    ExactInvertibility,
+    EqualityManifold
+include("types/invertibility.jl")
+export AbstractInvertibilityBound,
     NOverSqrtSpectral,
     NOverSpectral,
     OneOverSqrtSpectral,
     OneOverSpectral
-export invertibility_radius
-
+export default_invertibility_bound,
+    invertibility_radius
 # Scaled sphere, this structure is useful for comparison against parametrization
 include("types/ScaledSphere.jl")
 export ScaledSphere

--- a/src/solvers/tangent_solvers/MADSTangentSolver.jl
+++ b/src/solvers/tangent_solvers/MADSTangentSolver.jl
@@ -68,7 +68,7 @@ function solve!(
         g = nothing, max_evals::Int = 1000 * manifold_dimension(M), εeqs::Float64 = 1.0e-8
     )
     q = manifold_dimension(M)
-    radius = invertibility_radius(M, p, R, ρ)
+    radius = invertibility_radius(M, p; m = R, ρ = ρ)
 
     for budget in (10, max_evals)
         budget > max_evals && continue

--- a/src/types/EqualityManifold.jl
+++ b/src/types/EqualityManifold.jl
@@ -50,10 +50,6 @@ function eval_defining_hessians(M::EqualityManifold, p)
     return hessians
 end
 
-####################################################################
-# Checks on an `EqualityManifold` and its tangent spaces.
-####################################################################
-
 """
     check_size(M::EqualityManifold, p)
 
@@ -122,10 +118,6 @@ function check_vector(M::EqualityManifold, p, X; kwargs...)
     return nothing
 end
 
-####################################################################
-# Tangent spaces bases computation.
-####################################################################
-
 default_basis(::EqualityManifold) = DefaultOrthonormalBasis()
 
 """
@@ -178,10 +170,6 @@ function get_coordinates_orthonormal(M::EqualityManifold, p, X, N::AbstractNumbe
     return c
 end
 
-####################################################################
-# Projection
-####################################################################
-
 """
     project(M::EqualityManifold, p)
 
@@ -203,10 +191,6 @@ function ManifoldsBase.project(M::EqualityManifold, p)
     return q
 end
 
-####################################################################
-# Retractions
-####################################################################
-
 default_retraction_method(::EqualityManifold) = ProjectionRetraction()
 
 """
@@ -216,134 +200,12 @@ retract(M::EqualityManifold, p, X, ::ProjectionRetraction)
 
 function retract_project!(M::EqualityManifold, q, p, X)
     if !is_vector(M, p, X; atol = 1.0e-6)
-        # error("Vector $(X) is not a tangent vector to $(M) at $(p). It can not be retracted.")
+        error("Vector $(X) is not a tangent vector to $(M) at $(p). It can not be retracted.")
     end
     pX = p .+ X
     q = project(M, pX)
     return q
 end
-
-####################################################################
-# Injectivity radii
-# TODO. Change this hierarchy of definitions so that the injectivity_radius is called whenever the exponential map is defined, instead of relying on the Sphere only.
-####################################################################
-
-"""
-    AbstractInvertibilityBound
-
-A formula to compute a lower bound on the [`invertibility_radius`](@ref) of a manifold.
-"""
-abstract type AbstractInvertibilityBound end
-
-"""
-    ExactInvertibility <: AbstractInvertibilityBound
-
-When it exists, computes the exact value of the invertibility radius; i.e., the injectivity_radius of the exponential map in most cases.
-"""
-mutable struct ExactInvertibility <: AbstractInvertibilityBound end
-
-"""
-    OneOverSpectral <: AbstractInvertibilityBound
-
-Computes a lower bound on the [`invertibility_radius`](@ref) of the [`ProjectionRetraction`](@extref ManifoldsBase.ProjectionRetraction) as
-
-```math
-    \\frac{1}{\\max\\{\\lambda(H_{h_i}(x)) : i\\in\\{1,...,p\\}\\}}.
-```
-
-with ``\\lambda(H_{h_i})`` the spectral radius of the Hessian matrix of the defining subfunction ``h_i`` for `M`.
-"""
-mutable struct OneOverSpectral <: AbstractInvertibilityBound end
-
-"""
-    NOverSpectral <: AbstractInvertibilityBound
-
-Computes a lower bound on the [`invertibility_radius`](@ref) of the [`ProjectionRetraction`](@extref ManifoldsBase.ProjectionRetraction) as
-
-```math
-    \\frac{n}{\\max\\{\\lambda(H_{h_i}(x)) : i\\in\\{1,...,p\\}\\}}.
-```
-
-with ``\\lambda(H_{h_i})`` the spectral radius of the Hessian matrix of the defining subfunction ``h_i`` for `M`.
-"""
-mutable struct NOverSpectral <: AbstractInvertibilityBound end
-
-"""
-    OneOverSqrtSpectral <: AbstractInvertibilityBound
-
-Computes a lower bound on the [`invertibility_radius`](@ref) of the [`ProjectionRetraction`](@extref ManifoldsBase.ProjectionRetraction) as
-
-```math
-    \\frac{1}{\\sqrt{\\max\\{\\lambda(H_{h_i}(x)) : i\\in\\{1,...,p\\}\\}}}.
-```
-
-with ``\\lambda(H_{h_i})`` the spectral radius of the Hessian matrix of the defining subfunction ``h_i`` for `M`.
-"""
-mutable struct OneOverSqrtSpectral <: AbstractInvertibilityBound end
-
-"""
-    NOverSqrtSpectral <: AbstractInvertibilityBound
-
-Computes a lower bound on the [`invertibility_radius`](@ref) of the [`ProjectionRetraction`](@extref ManifoldsBase.ProjectionRetraction) as
-
-```math
-    \\frac{n}{\\sqrt{\\max\\{\\lambda(H_{h_i}(x)) : i\\in\\{1,...,p\\}\\}}}.
-```
-
-with ``\\lambda(H_{h_i})`` the spectral radius of the Hessian matrix of the defining subfunction ``h_i`` for `M`.
-"""
-mutable struct NOverSqrtSpectral <: AbstractInvertibilityBound end
-
-"""
-    invertibility_radius(M::AbstractManifold, p; m::AbstractRetractionMethod, b::AbstractInvertibilityBound)
-
-Return a lower bound on the [`invertibility_radius``](@ref) of `M` at `p` when endowed with the [`AbstractRetractionMethod`](@extref ManifoldsBase.AbstractRetractionMethod) `m`. The chosen bound is computed with the formula contained in `b`, and can be the exact value of the invertibility radius.
-"""
-function invertibility_radius(M::AbstractManifold, p; m::AbstractRetractionMethod, b::AbstractInvertibilityBound) end
-
-invertibility_radius(M::Manifolds.Sphere, p, m::StabilizedRetraction, b::ExactInvertibility) = injectivity_radius(M, p, m)
-
-"""
-    invertibility_bound(M::EqualityManifold, p; m::AbstractRetractionMethod, b::AbstractInvertibilityBound)
-
-Return a lower bound on the [`invertibility_radius`](@ref) of the [`EqualityManifold`](@ref) `M` at `p`, endowed with [`AbstractRetractionMethod`](@extref ManifoldsBase.AbstractRetractionMethod) `m`. The bound is computed according to the formula given by the [`AbstractInvertibilityBound`](@ref) `b`.
-"""
-invertibility_radius(M::EqualityManifold, p; m::AbstractRetractionMethod = default_retraction_method(M), b::AbstractInvertibilityBound = OneOverSpectral()) = invertibility_radius(M, p, m, b)
-
-function invertibility_radius(M::EqualityManifold, p, m::ProjectionRetraction, b::OneOverSpectral)
-    hessians = eval_defining_hessians(M, p)
-    spectral_radii = [maximum(abs, eigvals(hessian)) for hessian in hessians]
-    return 1 / maximum(spectral_radii)
-end
-
-function invertibility_radius(M::EqualityManifold, p, m::ProjectionRetraction, b::NOverSpectral)
-    n = representation_size(M)[1]
-    hessians = eval_defining_hessians(M, p)
-    spectral_radii = [maximum(abs, eigvals(hessian)) for hessian in hessians]
-    return n / maximum(spectral_radii)
-end
-
-function invertibility_radius(M::EqualityManifold, p, m::ProjectionRetraction, b::OneOverSqrtSpectral)
-    hessians = eval_defining_hessians(M, p)
-    spectral_radii = [maximum(abs, eigvals(hessian)) for hessian in hessians]
-    return 1 / sqrt(maximum(spectral_radii))
-end
-
-function invertibility_radius(M::EqualityManifold, p, m::ProjectionRetraction, b::NOverSqrtSpectral)
-    n = representation_size(M)[1]
-    hessians = eval_defining_hessians(M, p)
-    spectral_radii = [maximum(abs, eigvals(hessian)) for hessian in hessians]
-    return n / sqrt(maximum(spectral_radii))
-end
-
-function default_invertibility_bound(M::AbstractManifold, m::AbstractRetractionMethod) end
-
-default_invertibility_bound(::EqualityManifold, ::ProjectionRetraction) = NOverSqrtSpectral()
-default_invertibility_bound(::Manifolds.Sphere, ::StabilizedRetraction) = ExactInvertibility()
-
-####################################################################
-# Random choice of points
-####################################################################
 
 function ManifoldsBase.rand(M::EqualityManifold)
     n = representation_size(M)[1]

--- a/src/types/invertibility.jl
+++ b/src/types/invertibility.jl
@@ -86,7 +86,7 @@ When the manifold ``M`` is endowed with retraction method `m` at `p`, its invert
 
 This function returns a **lower bound** on this quantity, computed according to `ρ`. If `ρ` is an [`ExactInvertibility`](@ref), the exact value is returned.
 
-When `m` is the [`ExponentialRetraction`](@extref ManifoldsBase.ExponentialRetraction), this function falls back to the [`injectivity_radius`](@extref `ManifoldsBase.injectivity_radius`) of ``M`` at `p`.
+When `m` is the [`ExponentialRetraction`](@extref ManifoldsBase.ExponentialRetraction), this function falls back to the `injectivity_radius` of ``M`` at `p`.
 """
 function invertibility_radius(M::AbstractManifold, p; m::AbstractRetractionMethod = default_retraction_method(M), ρ::AbstractInvertibilityBound = default_invertibility_bound(M; m = default_retraction_method(M)))
     return _invertibility_radius(M, p, m, ρ)

--- a/src/types/invertibility.jl
+++ b/src/types/invertibility.jl
@@ -86,7 +86,7 @@ When the manifold ``M`` is endowed with retraction method `m` at `p`, its invert
 
 This function returns a **lower bound** on this quantity, computed according to `ρ`. If `ρ` is an [`ExactInvertibility`](@ref), the exact value is returned.
 
-When `m` is the [`ExponentialRetraction`](@extref ManifoldsBase.ExponentialRetraction), this function falls back to the [`injectivity_radius`](@extref ManifoldsBase) of ``M`` at `p`.
+When `m` is the [`ExponentialRetraction`](@extref ManifoldsBase.ExponentialRetraction), this function falls back to the [`injectivity_radius`](@extref `ManifoldsBase.injectivity_radius`) of ``M`` at `p`.
 """
 function invertibility_radius(M::AbstractManifold, p; m::AbstractRetractionMethod = default_retraction_method(M), ρ::AbstractInvertibilityBound = default_invertibility_bound(M; m = default_retraction_method(M)))
     return _invertibility_radius(M, p, m, ρ)

--- a/src/types/invertibility.jl
+++ b/src/types/invertibility.jl
@@ -1,0 +1,118 @@
+"""
+    AbstractInvertibilityBound
+
+A formula to compute a lower bound on the [`invertibility_radius`](@ref) of a manifold.
+"""
+abstract type AbstractInvertibilityBound end
+
+"""
+    ExactInvertibility <: AbstractInvertibilityBound
+
+Computes the exact value of the [`invertibility_radius`](@ref) of a retraction (if possible).
+"""
+mutable struct ExactInvertibility <: AbstractInvertibilityBound end
+
+"""
+    OneOverSpectral <: AbstractInvertibilityBound
+
+Computes a lower bound on the [`invertibility_radius`](@ref) of the [`ProjectionRetraction`](@extref ManifoldsBase.ProjectionRetraction) as
+
+```math
+    \\frac{1}{\\max\\{\\lambda(H_{h_i}(x)) : i\\in\\{1,...,p\\}\\}}.
+```
+
+with ``\\lambda(H_{h_i})`` the spectral radius of the Hessian matrix of the defining subfunction ``h_i`` for `M`.
+"""
+mutable struct OneOverSpectral <: AbstractInvertibilityBound end
+
+"""
+    NOverSpectral <: AbstractInvertibilityBound
+
+Computes a lower bound on the [`invertibility_radius`](@ref) of the [`ProjectionRetraction`](@extref ManifoldsBase.ProjectionRetraction) as
+
+```math
+    \\frac{n}{\\max\\{\\lambda(H_{h_i}(x)) : i\\in\\{1,...,p\\}\\}}.
+```
+
+with ``\\lambda(H_{h_i})`` the spectral radius of the Hessian matrix of the defining subfunction ``h_i`` for `M`.
+"""
+mutable struct NOverSpectral <: AbstractInvertibilityBound end
+
+"""
+    OneOverSqrtSpectral <: AbstractInvertibilityBound
+
+Computes a lower bound on the [`invertibility_radius`](@ref) of the [`ProjectionRetraction`](@extref ManifoldsBase.ProjectionRetraction) as
+
+```math
+    \\frac{1}{\\sqrt{\\max\\{\\lambda(H_{h_i}(x)) : i\\in\\{1,...,p\\}\\}}}.
+```
+
+with ``\\lambda(H_{h_i})`` the spectral radius of the Hessian matrix of the defining subfunction ``h_i`` for `M`.
+"""
+mutable struct OneOverSqrtSpectral <: AbstractInvertibilityBound end
+
+"""
+    NOverSqrtSpectral <: AbstractInvertibilityBound
+
+Computes a lower bound on the [`invertibility_radius`](@ref) of the [`ProjectionRetraction`](@extref ManifoldsBase.ProjectionRetraction) as
+
+```math
+    \\frac{n}{\\sqrt{\\max\\{\\lambda(H_{h_i}(x)) : i\\in\\{1,...,p\\}\\}}}.
+```
+
+with ``\\lambda(H_{h_i})`` the spectral radius of the Hessian matrix of the defining subfunction ``h_i`` for `M`.
+"""
+mutable struct NOverSqrtSpectral <: AbstractInvertibilityBound end
+
+"""
+    default_invertibility_bound(M::AbstractManifold, p; m::AbstractRetractionMethod)
+
+Return the default [`AbstractInvertibilityBound`](@ref) used to compute the [`invertibility_bound`](@ref) of ``M`` at `p` when endowed with the retraction method `m`. For an [`EqualityManifold`](@ref) endowed with the [`ProjectionRetraction`](@extref ManifoldsBase.ProjectionRetraction), defaults to [`NOverSpectral`](@ref).
+"""
+function default_invertibility_bound(M::AbstractManifold, p; m::AbstractRetractionMethod)
+    return ExactInvertibility()
+end
+default_invertibility_bound(::EqualityManifold, p; m::ProjectionRetraction) = NOverSpectral()
+
+"""
+    invertibility_radius(M::AbstractManifold, p; m::AbstractRetractionMethod, ρ::AbstractInvertibilityBound)
+
+When the manifold ``M`` is endowed with retraction method `m` at `p`, its invertibility radius is defined as
+
+```math
+    \\mathrm{inv}(p)=\\sup\\{\\delta>0\\; :\\; R_p\\text{ is a diffeomorphism from }B_p(0;\\delta)\\text{ onto its image}\\}.
+```
+
+This function returns a **lower bound** on this quantity, computed according to `ρ`. If `ρ` is an [`ExactInvertibility`](@ref), the exact value is returned.
+
+When `m` is the [`ExponentialRetraction`](@extref ManifoldsBase.ExponentialRetraction), this function falls back to the [`injectivity_radius`](@extref ManifoldsBase.injectivity_radius) of ``M`` at `p`.
+"""
+function invertibility_radius(M::AbstractManifold, p; m::AbstractRetractionMethod = default_retraction_method(M), ρ::AbstractInvertibilityBound = default_invertibility_bound(M)) end
+
+invertibility_radius(M::AbstractManifold, p; ::ExponentialRetraction, ::ExactInvertibility) = injectivity_radius(M, p)
+
+function invertibility_radius(M::EqualityManifold, p; m::ProjectionRetraction, ρ::OneOverSpectral)
+    Hhis = eval_defining_hessians(M, p)
+    Λ = [maximum(abs, eigvals(Hhi)) for Hhi in Hhis]
+    return 1 / maximum(Λ)
+end
+
+function invertibility_radius(M::EqualityManifold, p, m::ProjectionRetraction, ρ::NOverSpectral)
+    n = representation_size(M)[1]
+    Hhis = eval_defining_hessians(M, p)
+    Λ = [maximum(abs, eigvals(Hhi)) for Hhi in Hhis]
+    return n / maximum(Λ)
+end
+
+function invertibility_radius(M::EqualityManifold, p, m::ProjectionRetraction, ρ::OneOverSqrtSpectral)
+    Hhis = eval_defining_hessians(M, p)
+    Λ = [maximum(abs, eigvals(Hhi)) for Hhi in Hhis]
+    return 1 / sqrt(maximum(Λ))
+end
+
+function invertibility_radius(M::EqualityManifold, p, m::ProjectionRetraction, b::NOverSqrtSpectral)
+    n = representation_size(M)[1]
+    Hhis = eval_defining_hessians(M, p)
+    Λ = [maximum(abs, eigvals(Hhi)) for Hhi in Hhis]
+    return n / sqrt(maximum(Λ))
+end

--- a/src/types/invertibility.jl
+++ b/src/types/invertibility.jl
@@ -67,7 +67,7 @@ mutable struct NOverSqrtSpectral <: AbstractInvertibilityBound end
 """
     default_invertibility_bound(M::AbstractManifold; m::AbstractRetractionMethod)
 
-Return the default [`AbstractInvertibilityBound`](@ref) used to compute the [`invertibility_bound`](@ref) of ``M`` when endowed with the retraction method `m`. For an [`EqualityManifold`](@ref) endowed with the [`ProjectionRetraction`](@extref ManifoldsBase.ProjectionRetraction), defaults to [`NOverSpectral`](@ref).
+Return the default [`AbstractInvertibilityBound`](@ref) used to compute the [`invertibility_radius`](@ref) of ``M`` when endowed with the retraction method `m`. For an [`EqualityManifold`](@ref) endowed with the [`ProjectionRetraction`](@extref ManifoldsBase.ProjectionRetraction), defaults to [`NOverSpectral`](@ref).
 """
 function default_invertibility_bound(M::AbstractManifold; m::AbstractRetractionMethod = default_retraction_method(M))
     return _default_invertibility_bound(M, m)

--- a/src/types/invertibility.jl
+++ b/src/types/invertibility.jl
@@ -65,14 +65,15 @@ with ``\\lambda(H_{h_i})`` the spectral radius of the Hessian matrix of the defi
 mutable struct NOverSqrtSpectral <: AbstractInvertibilityBound end
 
 """
-    default_invertibility_bound(M::AbstractManifold, p; m::AbstractRetractionMethod)
+    default_invertibility_bound(M::AbstractManifold; m::AbstractRetractionMethod)
 
-Return the default [`AbstractInvertibilityBound`](@ref) used to compute the [`invertibility_bound`](@ref) of ``M`` at `p` when endowed with the retraction method `m`. For an [`EqualityManifold`](@ref) endowed with the [`ProjectionRetraction`](@extref ManifoldsBase.ProjectionRetraction), defaults to [`NOverSpectral`](@ref).
+Return the default [`AbstractInvertibilityBound`](@ref) used to compute the [`invertibility_bound`](@ref) of ``M`` when endowed with the retraction method `m`. For an [`EqualityManifold`](@ref) endowed with the [`ProjectionRetraction`](@extref ManifoldsBase.ProjectionRetraction), defaults to [`NOverSpectral`](@ref).
 """
-function default_invertibility_bound(M::AbstractManifold, p; m::AbstractRetractionMethod)
-    return ExactInvertibility()
+function default_invertibility_bound(M::AbstractManifold; m::AbstractRetractionMethod = default_retraction_method(M))
+    return _default_invertibility_bound(M, m)
 end
-default_invertibility_bound(::EqualityManifold, p; m::ProjectionRetraction) = NOverSpectral()
+_default_invertibility_bound(M::AbstractManifold, m::AbstractRetractionMethod) = ExactInvertibility()
+_default_invertibility_bound(M::EqualityManifold, m::ProjectionRetraction) = NOverSpectral()
 
 """
     invertibility_radius(M::AbstractManifold, p; m::AbstractRetractionMethod, ρ::AbstractInvertibilityBound)
@@ -87,30 +88,33 @@ This function returns a **lower bound** on this quantity, computed according to 
 
 When `m` is the [`ExponentialRetraction`](@extref ManifoldsBase.ExponentialRetraction), this function falls back to the [`injectivity_radius`](@extref ManifoldsBase.injectivity_radius) of ``M`` at `p`.
 """
-function invertibility_radius(M::AbstractManifold, p; m::AbstractRetractionMethod = default_retraction_method(M), ρ::AbstractInvertibilityBound = default_invertibility_bound(M)) end
+function invertibility_radius(M::AbstractManifold, p; m::AbstractRetractionMethod = default_retraction_method(M), ρ::AbstractInvertibilityBound = default_invertibility_bound(M; m = default_retraction_method(M)))
+    return _invertibility_radius(M, p, m, ρ)
+end
 
-invertibility_radius(M::AbstractManifold, p; ::ExponentialRetraction, ::ExactInvertibility) = injectivity_radius(M, p)
+_invertibility_radius(M::AbstractManifold, p, m::ExponentialRetraction, ρ::ExactInvertibility) = injectivity_radius(M, p)
+_invertibility_radius(M::Sphere, p, m::StabilizedRetraction, ρ::ExactInvertibility) = injectivity_radius(M, p)
 
-function invertibility_radius(M::EqualityManifold, p; m::ProjectionRetraction, ρ::OneOverSpectral)
+function _invertibility_radius(M::EqualityManifold, p, m::ProjectionRetraction, ρ::OneOverSpectral)
     Hhis = eval_defining_hessians(M, p)
     Λ = [maximum(abs, eigvals(Hhi)) for Hhi in Hhis]
     return 1 / maximum(Λ)
 end
 
-function invertibility_radius(M::EqualityManifold, p, m::ProjectionRetraction, ρ::NOverSpectral)
+function _invertibility_radius(M::EqualityManifold, p, m::ProjectionRetraction, ρ::NOverSpectral)
     n = representation_size(M)[1]
     Hhis = eval_defining_hessians(M, p)
     Λ = [maximum(abs, eigvals(Hhi)) for Hhi in Hhis]
     return n / maximum(Λ)
 end
 
-function invertibility_radius(M::EqualityManifold, p, m::ProjectionRetraction, ρ::OneOverSqrtSpectral)
+function _invertibility_radius(M::EqualityManifold, p, m::ProjectionRetraction, ρ::OneOverSqrtSpectral)
     Hhis = eval_defining_hessians(M, p)
     Λ = [maximum(abs, eigvals(Hhi)) for Hhi in Hhis]
     return 1 / sqrt(maximum(Λ))
 end
 
-function invertibility_radius(M::EqualityManifold, p, m::ProjectionRetraction, b::NOverSqrtSpectral)
+function _invertibility_radius(M::EqualityManifold, p, m::ProjectionRetraction, ρ::NOverSqrtSpectral)
     n = representation_size(M)[1]
     Hhis = eval_defining_hessians(M, p)
     Λ = [maximum(abs, eigvals(Hhi)) for Hhi in Hhis]

--- a/src/types/invertibility.jl
+++ b/src/types/invertibility.jl
@@ -86,7 +86,7 @@ When the manifold ``M`` is endowed with retraction method `m` at `p`, its invert
 
 This function returns a **lower bound** on this quantity, computed according to `ρ`. If `ρ` is an [`ExactInvertibility`](@ref), the exact value is returned.
 
-When `m` is the [`ExponentialRetraction`](@extref ManifoldsBase.ExponentialRetraction), this function falls back to the [`injectivity_radius`](@extref ManifoldsBase.injectivity_radius) of ``M`` at `p`.
+When `m` is the [`ExponentialRetraction`](@extref ManifoldsBase.ExponentialRetraction), this function falls back to the [`injectivity_radius`](@extref ManifoldsBase) of ``M`` at `p`.
 """
 function invertibility_radius(M::AbstractManifold, p; m::AbstractRetractionMethod = default_retraction_method(M), ρ::AbstractInvertibilityBound = default_invertibility_bound(M; m = default_retraction_method(M)))
     return _invertibility_radius(M, p, m, ρ)

--- a/src/types/invertibility.jl
+++ b/src/types/invertibility.jl
@@ -86,7 +86,7 @@ When the manifold ``M`` is endowed with retraction method `m` at `p`, its invert
 
 This function returns a **lower bound** on this quantity, computed according to `ρ`. If `ρ` is an [`ExactInvertibility`](@ref), the exact value is returned.
 
-When `m` is the [`ExponentialRetraction`](@extref ManifoldsBase.ExponentialRetraction), this function falls back to the `injectivity_radius` of ``M`` at `p`.
+When `m` is the [`ExponentialRetraction`](@extref ManifoldsBase.ExponentialRetraction), this function falls back to the injectivity radius of ``M`` at `p`.
 """
 function invertibility_radius(M::AbstractManifold, p; m::AbstractRetractionMethod = default_retraction_method(M), ρ::AbstractInvertibilityBound = default_invertibility_bound(M; m = default_retraction_method(M)))
     return _invertibility_radius(M, p, m, ρ)

--- a/test/invertibility.jl
+++ b/test/invertibility.jl
@@ -1,0 +1,13 @@
+@testset "Invertibility radii" begin
+    M1 = Sphere(2)
+    p1 = [0.0, 1.0, 0.0]
+    @test invertibility_radius(M1, p1) == π
+
+    h(p) = norm(p)^2 - 1
+    M2 = EqualityManifold(h, 1, 2)
+    p2 = [1.0, 0.0]
+    @test invertibility_radius(M2, p2) == 1
+    @test invertibility_radius(M2, p2; ρ = OneOverSpectral()) == 0.5
+    @test invertibility_radius(M2, p2; ρ = OneOverSqrtSpectral()) == 1 / sqrt(2)
+    @test invertibility_radius(M2, p2; ρ = NOverSqrtSpectral()) == 2 / sqrt(2)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,4 +10,5 @@ using Manopt:
     include("EqualityManifold.jl")
     include("StoppingCriteria.jl")
     include("TangentSolver.jl")
+    include("invertibility.jl")
 end


### PR DESCRIPTION
Closes #22.

The hierarchy is clearer than it was before, but does not really take into account the discussion in `Manifolds.jl`. It is focused on the fact that the invertibility radius is a generalization of the injectivity radius.