### PR TITLE
Create the BlackboxProblem structure

### DIFF
--- a/src/ConstrainedDFO.jl
+++ b/src/ConstrainedDFO.jl
@@ -58,6 +58,16 @@ export latin_hypercube_sampling,
     redirect_to_files,
     spherical_to_cartesian
 
+# Homemade structure for blackbox problems
+include("types/BlackboxProblem.jl")
+export BlackboxProblem,
+    BlackboxInstance
+export eval_eqs,
+    eval_ineqs,
+    eval_objective,
+    get_dimension,
+    get_n_eqs,
+    get_n_ineqs
 # Riemannian submanifolds of ℝ^n defined as feasible sets for equality constraints
 include("types/EqualityManifold.jl")
 export AbstractInvertibilityBound,

--- a/src/ConstrainedDFO.jl
+++ b/src/ConstrainedDFO.jl
@@ -67,7 +67,8 @@ export eval_eqs,
     eval_objective,
     get_dimension,
     get_n_eqs,
-    get_n_ineqs
+    get_n_ineqs,
+    get_x0
 # Riemannian submanifolds of ℝ^n defined as feasible sets for equality constraints
 include("types/EqualityManifold.jl")
 export AbstractInvertibilityBound,

--- a/src/solvers/DFROSolver.jl
+++ b/src/solvers/DFROSolver.jl
@@ -1,31 +1,16 @@
 """
-Retract the point ``v\\in T_p\\mathcal{M}`` and then evaluate the objective at this retracted point.
-"""
-retract_eval(M::AbstractManifold, mco::AbstractManifoldCostObjective, p, v, retraction_method::AbstractRetractionMethod, solver::AbstractTangentSolver)
-
-function retract_eval(M::AbstractManifold, mco::AbstractManifoldCostObjective, p, v, retraction_method::AbstractRetractionMethod, solver::MADSTangentSolver; inequality_constraints::Union{Function, Nothing} = nothing, nb_inequalities::Int = 0, εeqs::Float64 = 1.0e-8)
-    return try
-        d = get_vector(M, p, v, DefaultOrthonormalBasis())
-        Pd = retract(M, p, d, retraction_method)
-        fd = is_point(M, Pd; atol = εeqs) ? [get_cost(M, mco, Pd)] : [1.0e20]
-        if isnothing(inequality_constraints)
-            return (true, true, fd)
-        else
-            gd = inequality_constraints(Pd)
-            return (true, true, [fd; gd])
-        end
-    catch e
-        println("FAAAILED: $(e)")
-        if isnothing(inequality_constraints)
-            return (true, true, [1.0e20])
-        else
-            return (true, true, [[1.0e20] ; [1.0e20 for _ in 1:nb_inequalities]])
-        end
-    end
-end
-
-"""
-    TODO.
+    DFROSolver(
+        M::AbstractManifold,
+        f::Function,
+        p0;
+        inequality_constraints::Union{Function, Nothing} = nothing,
+        solver::AbstractTangentSolver = MADSTangentSolver(),
+        max_evals::Int = 1000 * representation_size(M)[1],
+        stopping_criterion::DFStoppingCriterion = StopRadiusAndBudget(max_evals),
+        retraction_method::AbstractRetractionMethod = default_retraction_method(M),
+        invertibility_bound::AbstractInvertibilityBound = default_invertibility_bound(M, retraction_method),
+        εeqs::Float64 = 1.0e-8
+    )
 """
 function DFROSolver(
         M::AbstractManifold,
@@ -226,6 +211,7 @@ function DFROSolver(
     return p, eval_data[1:n_evals], iterates_history, objective_history, v_history, d_history, main_iterates
 end
 
+# TODO. Those should go. All of this is within the tangent solver's storage attributes.
 function vs_to_ds(M::AbstractManifold, p, vs)
     n_evals = size(vs)[1]
     q = representation_size(M)[1]

--- a/src/types/BlackboxProblem.jl
+++ b/src/types/BlackboxProblem.jl
@@ -3,12 +3,14 @@
 """
 mutable struct BlackboxProblem
     n::Int
-    m::Int
     p::Int
+    m::Int
     f::Function
-    g::Function
     h::Function
+    g::Function
 end
+
+BlackboxProblem(n, p, f, h) = BlackboxProblem(n, p, 0, f, h, x -> Float64[])
 
 get_dimension(BP::BlackboxProblem) = BP.n
 get_n_ineqs(BP::BlackboxProblem) = BP.m

--- a/src/types/BlackboxProblem.jl
+++ b/src/types/BlackboxProblem.jl
@@ -35,3 +35,5 @@ get_n_eqs(BI::BlackboxInstance) = BI.core_problem.p
 eval_objective(BI::BlackboxInstance, x) = BI.core_problem.f(x)
 eval_ineqs(BI::BlackboxInstance, x) = BI.core_problem.g(x)
 eval_eqs(BI::BlackboxInstance, x) = BI.core_problem.h(x)
+
+get_x0(BI::BlackboxInstance) = BI.x0

--- a/src/types/BlackboxProblem.jl
+++ b/src/types/BlackboxProblem.jl
@@ -1,0 +1,35 @@
+"""
+    BlackboxProblem
+"""
+mutable struct BlackboxProblem
+    n::Int
+    m::Int
+    p::Int
+    f::Function
+    g::Function
+    h::Function
+end
+
+get_dimension(BP::BlackboxProblem) = BP.n
+get_n_ineqs(BP::BlackboxProblem) = BP.m
+get_n_eqs(BP::BlackboxProblem) = BP.p
+
+eval_objective(BP::BlackboxProblem, x) = BP.f(x)
+eval_ineqs(BP::BlackboxProblem, x) = BP.g(x)
+eval_eqs(BP::BlackboxProblem, x) = BP.h(x)
+
+"""
+    BlackboxInstance
+"""
+mutable struct BlackboxInstance
+    core_problem::BlackboxProblem
+    x0::Vector{Float64}
+end
+
+get_dimension(BI::BlackboxInstance) = get_dimension(BI.core_problem)
+get_n_ineqs(BI::BlackboxInstance) = BI.core_problem.m
+get_n_eqs(BI::BlackboxInstance) = BI.core_problem.p
+
+eval_objective(BI::BlackboxInstance, x) = BI.core_problem.f(x)
+eval_ineqs(BI::BlackboxInstance, x) = BI.core_problem.g(x)
+eval_eqs(BI::BlackboxInstance, x) = BI.core_problem.h(x)

--- a/src/types/EqualityManifold.jl
+++ b/src/types/EqualityManifold.jl
@@ -170,3 +170,10 @@ function ManifoldsBase.rand(M::EqualityManifold)
     projp = project(M, p)
     return projp
 end
+
+function EqualityManifold(BP::BlackboxProblem)
+    defining_function(x) = eval_eqs(BP, x)
+    n = get_dimension(BP)
+    p = get_n_eqs(BP)
+    return EqualityManifold(defining_function, n - p, n)
+end

--- a/test/BlackboxProblem.jl
+++ b/test/BlackboxProblem.jl
@@ -3,7 +3,7 @@
     @test get_dimension(BP) == 2
     @test get_n_ineqs(BP) == 0
     @test get_n_eqs(BP) == 1
-    
+
     x = [1.0, -1.0]
     @test eval_objective(BP, x) == 0.0
     @test eval_ineqs(BP, x) == Float64[]
@@ -13,9 +13,13 @@
     @test get_dimension(BI) == 2
     @test get_n_ineqs(BI) == 0
     @test get_n_eqs(BI) == 1
-    
+
     @test eval_objective(BI, x) == 0.0
     @test eval_ineqs(BI, x) == Float64[]
     @test eval_eqs(BI, x) == [0.0]
     @test get_x0(BI) == [0.0, 0.0]
+
+    M = EqualityManifold(BP)
+    @test representation_size(M)[1] == 2
+    @test manifold_dimension(M) == 1
 end

--- a/test/BlackboxProblem.jl
+++ b/test/BlackboxProblem.jl
@@ -1,5 +1,3 @@
-using NLPModels
-
 @testset "BlackboxProblem" begin
     BP = BlackboxProblem(2, 1, x -> x[1] + x[2], x -> [x[1] - 1])
     @test get_dimension(BP) == 2
@@ -10,4 +8,14 @@ using NLPModels
     @test eval_objective(BP, x) == 0.0
     @test eval_ineqs(BP, x) == Float64[]
     @test eval_eqs(BP, x) == [0.0]
+
+    BI = BlackboxInstance(BP, [0.0, 0.0])
+    @test get_dimension(BI) == 2
+    @test get_n_ineqs(BI) == 0
+    @test get_n_eqs(BI) == 1
+    
+    @test eval_objective(BI, x) == 0.0
+    @test eval_ineqs(BI, x) == Float64[]
+    @test eval_eqs(BI, x) == [0.0]
+    @test get_x0(BI) == [0.0, 0.0]
 end

--- a/test/BlackboxProblem.jl
+++ b/test/BlackboxProblem.jl
@@ -1,0 +1,13 @@
+using NLPModels
+
+@testset "BlackboxProblem" begin
+    BP = BlackboxProblem(2, 1, x -> x[1] + x[2], x -> [x[1] - 1])
+    @test get_dimension(BP) == 2
+    @test get_n_ineqs(BP) == 0
+    @test get_n_eqs(BP) == 1
+    
+    x = [1.0, -1.0]
+    @test eval_objective(BP, x) == 0.0
+    @test eval_ineqs(BP, x) == Float64[]
+    @test eval_eqs(BP, x) == [0.0]
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ using Manopt:
     ManifoldCostObjective
 
 @testset "ConstrainedDFO.jl" begin
+    include("BlackboxProblem.jl")
     include("EqualityManifold.jl")
     include("StoppingCriteria.jl")
     include("TangentSolver.jl")


### PR DESCRIPTION
The `BlackboxProblem` and `BlackboxInstance` structure will be the core structures used to offer a unified interface to solvers in this package.

They replace the `BenchmarkEqualityProblem` structure. This allows to close #29 .