### PR TITLE
Refactor dfro solver

### DIFF
--- a/src/ConstrainedDFO.jl
+++ b/src/ConstrainedDFO.jl
@@ -48,7 +48,9 @@ using Manopt:
 using NOMAD
 using Random
 using ResumableFunctions
+using Printf
 
+EOL::String = "\n"
 void_constraint(::Any) = Float64[]
 
 include("utils/latin_hypercube_sampling.jl")

--- a/src/ConstrainedDFO.jl
+++ b/src/ConstrainedDFO.jl
@@ -78,6 +78,9 @@ export eval_eqs,
 include("types/EqualityManifold.jl")
 export AbstractInvertibilityBound,
     EqualityManifold
+# Dispatchers for the numerical check methods on Manifolds
+include("types/checks_dispatchers.jl")
+export is_point_dispatcher
 include("types/invertibility.jl")
 export AbstractInvertibilityBound,
     ExactInvertibility,
@@ -124,7 +127,7 @@ export blackbox_wrapper_store!,
     get_data_g,
     get_data_Rpv,
     get_last_subproblem_result,
-    get_radius_flag,
+    get_radius_evaluation,
     solve!
 include("solvers/tangent_solvers/MADSTangentSolver.jl")
 export MADSTangentSolver

--- a/src/ConstrainedDFO.jl
+++ b/src/ConstrainedDFO.jl
@@ -53,6 +53,7 @@ include("utils/latin_hypercube_sampling.jl")
 include("utils/redirect.jl")
 include("utils/spherical_coordinates.jl")
 include("utils/exceptions.jl")
+include("utils/void_constraint.jl")
 export NumericalError
 export latin_hypercube_sampling,
     redirect_to_files,

--- a/src/ConstrainedDFO.jl
+++ b/src/ConstrainedDFO.jl
@@ -44,6 +44,7 @@ using Manopt:
     AbstractManifoldCostObjective,
     AbstractManoptProblem,
     AbstractManoptSolverState,
+    ManifoldCostObjective,
     get_cost
 using NOMAD
 using Random

--- a/src/ConstrainedDFO.jl
+++ b/src/ConstrainedDFO.jl
@@ -49,11 +49,12 @@ using NOMAD
 using Random
 using ResumableFunctions
 
+void_constraint(::Any) = Float64[]
+
 include("utils/latin_hypercube_sampling.jl")
 include("utils/redirect.jl")
 include("utils/spherical_coordinates.jl")
 include("utils/exceptions.jl")
-include("utils/void_constraint.jl")
 export NumericalError
 export latin_hypercube_sampling,
     redirect_to_files,

--- a/src/solvers/DFROSolver.jl
+++ b/src/solvers/DFROSolver.jl
@@ -78,24 +78,24 @@ function DFROSolver(
         # First line: display outer_counter and ρ
         if print_level == 1
             first_line_log = @sprintf(
-                " %-10d%-12.6f%-10d%-15.6f%-10s%-20s",
-                outer_counter, radius, 1, data_f[1], "", data_Rpv[1]
+                " %-10d%-12.6f%-10d%-15.6f%-10s%-20s%-10s",
+                outer_counter, radius, 1, data_f[1], "", data_Rpv[1], is_point(M, data_Rpv[1])
             )
             println(first_line_log)
         end
         # Then, display the rest
         last_eval = improvement_outside_radius ? radius_evaluation : n_evals
         if print_level == 1
-            for eval in 2:(last_eval - 1)
-                line_log = @sprintf(
-                    " %-10s%-12s%-10d%-15.6f%-10s%-20s",
-                    "", "", eval, data_f[eval], "", data_Rpv[eval]
-                )
-                println(line_log)
-            end
+            # for eval in 2:(last_eval - 1)
+            #     line_log = @sprintf(
+            #         " %-10s%-12s%-10d%-15.6f%-10s%-20s%-10s",
+            #         "", "", eval, data_f[eval], "", data_Rpv[eval], is_point(M, data_Rpv[eval])
+            #     )
+            #     println(line_log)
+            # end
             last_line_log = @sprintf(
-                " %-10s%-12s%-10d%-15.6f%-10s%-20s",
-                "", "", last_eval, data_f[last_eval], improvement_outside_radius ? "✓" : "✗", data_Rpv[last_eval]
+                " %-10s%-12s%-10d%-15.6f%-10s%-20s%-10s",
+                "", "", last_eval, data_f[last_eval], improvement_outside_radius ? "✓" : "✗", data_Rpv[last_eval], is_point(M, data_Rpv[last_eval])
             )
             println(last_line_log)
         end

--- a/src/solvers/DFROSolver.jl
+++ b/src/solvers/DFROSolver.jl
@@ -27,13 +27,14 @@ function DFROSolver(
 
     separator = @sprintf(
         "%s%s%s%s%s",
-        "-"^4, "-"^6, "-"^4, "-"^11, "-"^5
+        "-"^11, "-"^12, "-"^10, "-"^15, "-"^11
     )
     header = @sprintf(
-        " %-5s%-7s%-5s%-12s%-5s",
-        "ℓ", "ρ", "k", "f", "‖v‖≥ρ"
+        " %-10s%-12s%-10s%-15s%-10s",
+        "Outer", "Radius", "Inner", "Objective", "‖v‖≥ρ"
     )
 
+    println(separator)
     println(header)
     println(separator)
 
@@ -60,7 +61,7 @@ function DFROSolver(
         # Print data from the tangent solver
         # First line: display ℓ and ρ
         first_line_log = @sprintf(
-            " %5d%7.3f%5d%12.6f%5s",
+            " %-10d%-12.6f%-10d%-15.6f%-10s",
             ℓ, radius, 1, data_f[1], ""
         )
         println(first_line_log)
@@ -68,13 +69,13 @@ function DFROSolver(
         last_eval = solved_outside_radius ? radius_evaluation : n_evals
         for eval in 2:(last_eval - 1)
             line_log = @sprintf(
-                " %5s%7s%5d%12.6f%5s",
+                " %-10s%-12s%-10d%-15.6f%-10s",
                 "", "", eval, data_f[eval], ""
             )
             println(line_log)
         end
         last_line_log = @sprintf(
-            " %5s%7s%5d%12.6f%5s",
+            " %-10s%-12s%-10d%-15.6f%-10s",
             "", "", last_eval, data_f[last_eval], solved_outside_radius ? "✓" : "✗"
         )
         println(last_line_log)

--- a/src/solvers/DFROSolver.jl
+++ b/src/solvers/DFROSolver.jl
@@ -29,11 +29,85 @@ function DFROSolver(
 end
 
 """
-This one will take a `BlackboxProblem` as an input. Highest level in the hierarchy.
+In the top-level function
+- build the DFROState object
+- manage whether to return the DFROState object
+- possibly, redirect stdout to a stat file (that does not necessarily meet the format of the RunnerPost: a converter should be implemented later).
+- project p0 to M if it is not feasible from the beginning.
 """
-function DFROSolver(
-
+function DFROSolver!(
+        M::AbstractManifold,
+        mco::AbstractManifoldCostObjective,
+        g,
+        p0,
+        m::Int,
+        dfros::DFROState,
+        tangent_solver::AbstractTangentSolver,
+        max_evals::Int,
+        stopping_criterion::DFStoppingCriterion,
+        R::AbstractRetractionMethod,
+        ρ::AbstractInvertibilityBound,
+        εeqs::Float64,
+        εineqs::Float64,
     )
+    header = @sprintf(
+        " %-5s%-7s%-5s%-12s%-5s",
+        "ℓ", "ρ", "k", "f", "‖v‖≥ρ"
+    )
+    separator = @sprintf(
+        "+%s+%s+%s+%s+%s+",
+        "-"^4, "-"^6, "-"^4, "-"^11, "-"^5
+    )
+
+    @printf header * EOL
+    @printf separator * EOL
+
+    ℓ = 0
+    remaining_eval_budget = max_evals
+    termination::Bool = false
+    while !termination
+        ℓ += 1
+
+        # Compute a lower bound to the invertibility radius at p
+        radius = invertibility_radius(M, p, R, ρ)
+
+        # Solve the subproblem in the current tangent space
+        solve!(tangent_solver, mco, M, p, R, radius, n_ineqs; max_evals = remaining_eval_budget, εeqs = εeqs)
+
+        # Retrieve data from the tangent solver
+        data_f = get_data_f(tangent_solver)
+        n_evals = length(data_f)
+        radius_evaluation = tangent_solver.radius_evaluation
+        solved_outside_radius = radius_evaluation > 0
+
+        # Print data from the tangent solver
+        # First line: display ℓ and ρ
+        first_line_log = @sprintf(
+            " %5d%7.3f%5d%12.3f%5s",
+            ℓ, radius, 1, data_f[1], ""
+        )
+        @printf first_line_log * EOL
+        # Then, display the rest
+        last_eval = solved_outside_radius ? radius_evaluation : n_evals
+        for eval in 2:(last_eval - 1)
+            line_log = @sprintf(
+                " %5d%7.3f%5d%12.3f%5s",
+                "", "", eval, data_f[eval], ""
+            )
+            @printf line_log * EOL
+        end
+        last_line_log = @sprintf(
+            " %5d%7.3f%5d%12.3f%5s",
+            "", "", last_eval, data_f[last_eval], solved_outside_radius ? "✓" : "✗"
+        )
+        @print last_line_log * EOL
+
+        # Update remaining evaluations
+        remaining_eval_budget -= last_eval
+        termination = true
+    end
+
+    return dfros
 end
 
 function DFROSolver(

--- a/src/solvers/DFROSolver.jl
+++ b/src/solvers/DFROSolver.jl
@@ -105,6 +105,7 @@ function DFROSolver!(
         # Update remaining evaluations
         remaining_eval_budget -= last_eval
         termination = true
+        # TODO: Think of changing attributes of the State object!
     end
 
     return dfros

--- a/src/solvers/DFROSolver.jl
+++ b/src/solvers/DFROSolver.jl
@@ -35,20 +35,23 @@ function DFROSolver(
         invertibility_bound::AbstractInvertibilityBound = default_invertibility_bound(M),
         tol_eqs::Float64 = 1.0e-8,
         tol_ineqs::Float64 = 1.0e-8,
+        print_level::Int = 1
     )
 
-    separator = @sprintf(
-        "%s%s%s%s%s",
-        "-"^11, "-"^12, "-"^10, "-"^15, "-"^11
-    )
-    header = @sprintf(
-        " %-10s%-12s%-10s%-15s%-10s",
-        "Outer", "Radius", "Inner", "Objective", "‖v‖≥ρ"
-    )
+    if print_level == 1
+        separator = @sprintf(
+            "%s%s%s%s%s",
+            "-"^11, "-"^12, "-"^10, "-"^15, "-"^11
+        )
+        header = @sprintf(
+            " %-10s%-12s%-10s%-15s%-10s",
+            "Outer", "Radius", "Inner", "Objective", "‖v‖≥ρ"
+        )
 
-    println(separator)
-    println(header)
-    println(separator)
+        println(separator)
+        println(header)
+        println(separator)
+    end
 
     outer_counter = 0
     p = p0
@@ -72,25 +75,29 @@ function DFROSolver(
 
         # Print data from the tangent solver
         # First line: display outer_counter and ρ
-        first_line_log = @sprintf(
-            " %-10d%-12.6f%-10d%-15.6f%-10s",
-            outer_counter, radius, 1, data_f[1], ""
-        )
-        println(first_line_log)
+        if print_level == 1
+            first_line_log = @sprintf(
+                " %-10d%-12.6f%-10d%-15.6f%-10s",
+                outer_counter, radius, 1, data_f[1], ""
+            )
+            println(first_line_log)
+        end
         # Then, display the rest
         last_eval = improvement_outside_radius ? radius_evaluation : n_evals
-        for eval in 2:(last_eval - 1)
-            line_log = @sprintf(
+        if print_level == 1
+            for eval in 2:(last_eval - 1)
+                line_log = @sprintf(
+                    " %-10s%-12s%-10d%-15.6f%-10s",
+                    "", "", eval, data_f[eval], "",
+                )
+                println(line_log)
+            end
+            last_line_log = @sprintf(
                 " %-10s%-12s%-10d%-15.6f%-10s",
-                "", "", eval, data_f[eval], "",
+                "", "", last_eval, data_f[last_eval], improvement_outside_radius ? "✓" : "✗"
             )
-            println(line_log)
+            println(last_line_log)
         end
-        last_line_log = @sprintf(
-            " %-10s%-12s%-10d%-15.6f%-10s",
-            "", "", last_eval, data_f[last_eval], improvement_outside_radius ? "✓" : "✗"
-        )
-        println(last_line_log)
 
         # Find the solution of the subproblem in the logs and make it the new iterate
         # Be careful: do not look for the best value of f amongst the points that were only virtually evaluated.

--- a/src/solvers/DFROSolver.jl
+++ b/src/solvers/DFROSolver.jl
@@ -12,7 +12,7 @@
 Keyword arguments can include:
 - `tangent_solver::AbstractTangentSolver` is the tangent solver used. Defaults to [`MADSTangentSolver`](@ref).
 - `max_evals::Int` is the budget of evaluations to solve the problem. Defaults to ``1000\\times n`` where ``n`` is the dimension of the problem.
-- `retraction_method::AbstractRetractionMethod` is the method used to retract tangent vectors to the manifold while solving subproblems. Defaults to `default_retraction_method(M)` (see [`default_retraction_method`](@extref ManifoldsBase.default_retraction_method)).
+- `retraction_method::AbstractRetractionMethod` is the method used to retract tangent vectors to the manifold while solving subproblems. Defaults to `default_retraction_method(M)`.
 - `invertibility_bound::AbstractInvertibilityBound` is the formula used to compute a lower bound on the invertibility radius of ``\\mathcal{M}``. Defaults to `default_invertibility_bound(M)` (see [`invertibility_radius`](@ref) and [`default_invertibility_bound`](@ref)).
 - `tol_eqs::Float64` is the numerical tolerance below which a point is considered feasible for equality constraints. Defaults to ``1.0\\times 10^{-8}``.
 - `tol_ineqs::Float64` is the numerical tolerance below which a point is considered feasible for inequality constraints. Defaults to ``1.0\\times 10^{-8}``.

--- a/src/solvers/DFROSolver.jl
+++ b/src/solvers/DFROSolver.jl
@@ -86,13 +86,13 @@ function DFROSolver(
         # Then, display the rest
         last_eval = improvement_outside_radius ? radius_evaluation : n_evals
         if print_level == 1
-            # for eval in 2:(last_eval - 1)
-            #     line_log = @sprintf(
-            #         " %-10s%-12s%-10d%-15.6f%-10s%-20s%-10s",
-            #         "", "", eval, data_f[eval], "", data_Rpv[eval], is_point(M, data_Rpv[eval])
-            #     )
-            #     println(line_log)
-            # end
+            for eval in 2:(last_eval - 1)
+                line_log = @sprintf(
+                    " %-10s%-12s%-10d%-15.6f%-10s%-20s%-10s",
+                    "", "", eval, data_f[eval], "", data_Rpv[eval], is_point(M, data_Rpv[eval])
+                )
+                println(line_log)
+            end
             last_line_log = @sprintf(
                 " %-10s%-12s%-10d%-15.6f%-10s%-20s%-10s",
                 "", "", last_eval, data_f[last_eval], improvement_outside_radius ? "✓" : "✗", data_Rpv[last_eval], is_point(M, data_Rpv[last_eval])

--- a/src/solvers/DFROSolver.jl
+++ b/src/solvers/DFROSolver.jl
@@ -1,16 +1,28 @@
+"""
+    DFROSolver(M::AbstractManifold, f, g, p0, n_ineqs::Int; kwargs...)
+
+# Arguments
+- `M` is the Riemannian submanifold of ``\\mathbb{R}^n`` where the optimization problem is solved.
+- `f` is the cost function.
+- `g` gives the inequality constraints.
+- `p0` is the starting point used by the solver. If ``p_0\\notin\\mathcal{M}``, then the actual starting point used is ``\\mathrm{proj}_{\\mathcal{M}}(p_0)``.
+- `n_ineqs` is the number of inequality constraints.
+
+# Keyword arguments
+Keyword arguments can include:
+- `tangent_solver::AbstractTangentSolver` is the tangent solver used. Defaults to [`MADSTangentSolver`](@ref).
+- `max_evals::Int` is the budget of evaluations to solve the problem. Defaults to ``1000\\times n`` where ``n`` is the dimension of the problem.
+- `retraction_method::AbstractRetractionMethod` is the method used to retract tangent vectors to the manifold while solving subproblems. Defaults to `default_retraction_method(M)` (see [`default_retraction_method`](@extref ManifoldsBase.default_retraction_method)).
+- `invertibility_bound::AbstractInvertibilityBound` is the formula used to compute a lower bound on the invertibility radius of ``\\mathcal{M}``. Defaults to `default_invertibility_bound(M)` (see [`invertibility_radius`](@ref) and [`default_invertibility_bound`](@ref)).
+- `tol_eqs::Float64` is the numerical tolerance below which a point is considered feasible for equality constraints. Defaults to ``1.0\\times 10^{-8}``.
+- `tol_ineqs::Float64` is the numerical tolerance below which a point is considered feasible for inequality constraints. Defaults to ``1.0\\times 10^{-8}``.
+"""
 function DFROSolver(M::AbstractManifold, f, g, p0, n_ineqs::Int; kwargs...)
     cost(M, p) = f(p)
     mco = ManifoldCostObjective(cost)
     return DFROSolver(M, mco, g, p0, n_ineqs; kwargs...)
 end
 
-"""
-In the top-level function
-- build the DFROState object
-- manage whether to return the DFROState object
-- possibly, redirect stdout to a stat file (that does not necessarily meet the format of the RunnerPost: a converter should be implemented later).
-- project p0 to M if it is not feasible from the beginning.
-"""
 function DFROSolver(
         M::AbstractManifold,
         mco::AbstractManifoldCostObjective,

--- a/src/solvers/DFROSolver.jl
+++ b/src/solvers/DFROSolver.jl
@@ -78,7 +78,7 @@ function DFROSolver(
         # First line: display outer_counter and ρ
         if print_level == 1
             first_line_log = @sprintf(
-                " %-10d%-12.6f%-10d%-15.6f%-10s%",
+                " %-10d%-12.6f%-10d%-15.6f%-10s",
                 outer_counter, radius, 1, data_f[1], ""
             )
             println(first_line_log)

--- a/src/solvers/DFROSolver.jl
+++ b/src/solvers/DFROSolver.jl
@@ -1,31 +1,7 @@
-"""
-    DFROSolver(
-        M::AbstractManifold,
-        f::Function,
-        p0;
-        inequality_constraints::Union{Function, Nothing} = nothing,
-        solver::AbstractTangentSolver = MADSTangentSolver(),
-        max_evals::Int = 1000 * representation_size(M)[1],
-        stopping_criterion::DFStoppingCriterion = StopRadiusAndBudget(max_evals),
-        retraction_method::AbstractRetractionMethod = default_retraction_method(M),
-        invertibility_bound::AbstractInvertibilityBound = default_invertibility_bound(M, retraction_method),
-        εeqs::Float64 = 1.0e-8
-    )
-"""
-function DFROSolver(
-        M::AbstractManifold,
-        f::Function,
-        p0;
-        inequality_constraints::Union{Function, Nothing} = nothing,
-        solver::AbstractTangentSolver = MADSTangentSolver(),
-        max_evals::Int = 1000 * representation_size(M)[1],
-        stopping_criterion::DFStoppingCriterion = StopRadiusAndBudget(max_evals),
-        retraction_method::AbstractRetractionMethod = default_retraction_method(M),
-        invertibility_bound::AbstractInvertibilityBound = default_invertibility_bound(M, retraction_method),
-        εeqs::Float64 = 1.0e-8
-    )
-    mco = ManifoldCostObjective(f)
-    return DFRO(M, mco, p0; inequality_constraints = inequality_constraints, solver = solver, max_evals = max_evals, stopping_criterion = stopping_criterion, retraction_method = retraction_method, invertibility_bound = invertibility_bound, εeqs = εeqs)
+function DFROSolver(M::AbstractManifold, f, g, p0, n_ineqs::Int; kwargs...)
+    cost(M, p) = f(p)
+    mco = ManifoldCostObjective(cost)
+    return DFROSolver(M, mco, g, p0, n_ineqs; kwargs...)
 end
 
 """
@@ -35,47 +11,48 @@ In the top-level function
 - possibly, redirect stdout to a stat file (that does not necessarily meet the format of the RunnerPost: a converter should be implemented later).
 - project p0 to M if it is not feasible from the beginning.
 """
-function DFROSolver!(
+function DFROSolver(
         M::AbstractManifold,
         mco::AbstractManifoldCostObjective,
         g,
         p0,
         m::Int,
-        dfros::DFROState,
-        tangent_solver::AbstractTangentSolver,
-        max_evals::Int,
-        stopping_criterion::DFStoppingCriterion,
-        R::AbstractRetractionMethod,
-        ρ::AbstractInvertibilityBound,
-        εeqs::Float64,
-        εineqs::Float64,
+        tangent_solver::AbstractTangentSolver = MADSTangentSolver(),
+        max_evals::Int = 1000 * representation_size(M)[1],
+        retraction_method::AbstractRetractionMethod = default_retraction_method(M),
+        invertibility_bound::AbstractInvertibilityBound = default_invertibility_bound(M),
+        tol_eqs::Float64 = 1.0e-8,
+        tol_ineqs::Float64 = 1.0e-8,
+    )
+
+    separator = @sprintf(
+        "%s%s%s%s%s",
+        "-"^4, "-"^6, "-"^4, "-"^11, "-"^5
     )
     header = @sprintf(
         " %-5s%-7s%-5s%-12s%-5s",
         "ℓ", "ρ", "k", "f", "‖v‖≥ρ"
     )
-    separator = @sprintf(
-        "+%s+%s+%s+%s+%s+",
-        "-"^4, "-"^6, "-"^4, "-"^11, "-"^5
-    )
 
-    @printf header * EOL
-    @printf separator * EOL
+    println(header)
+    println(separator)
 
     ℓ = 0
+    p = p0
     remaining_eval_budget = max_evals
     termination::Bool = false
     while !termination
         ℓ += 1
 
         # Compute a lower bound to the invertibility radius at p
-        radius = invertibility_radius(M, p, R, ρ)
+        radius = invertibility_radius(M, p; m = retraction_method, ρ = invertibility_bound)
 
         # Solve the subproblem in the current tangent space
-        solve!(tangent_solver, mco, M, p, R, radius, n_ineqs; max_evals = remaining_eval_budget, εeqs = εeqs)
+        solve!(tangent_solver, mco, M, p, retraction_method, radius, m; max_evals = remaining_eval_budget, εeqs = tol_eqs)
 
         # Retrieve data from the tangent solver
         data_f = get_data_f(tangent_solver)
+        data_Rpv = get_data_Rpv(tangent_solver)
         n_evals = length(data_f)
         radius_evaluation = tangent_solver.radius_evaluation
         solved_outside_radius = radius_evaluation > 0
@@ -83,258 +60,33 @@ function DFROSolver!(
         # Print data from the tangent solver
         # First line: display ℓ and ρ
         first_line_log = @sprintf(
-            " %5d%7.3f%5d%12.3f%5s",
+            " %5d%7.3f%5d%12.6f%5s",
             ℓ, radius, 1, data_f[1], ""
         )
-        @printf first_line_log * EOL
+        println(first_line_log)
         # Then, display the rest
         last_eval = solved_outside_radius ? radius_evaluation : n_evals
         for eval in 2:(last_eval - 1)
             line_log = @sprintf(
-                " %5d%7.3f%5d%12.3f%5s",
+                " %5s%7s%5d%12.6f%5s",
                 "", "", eval, data_f[eval], ""
             )
-            @printf line_log * EOL
+            println(line_log)
         end
         last_line_log = @sprintf(
-            " %5d%7.3f%5d%12.3f%5s",
+            " %5s%7s%5d%12.6f%5s",
             "", "", last_eval, data_f[last_eval], solved_outside_radius ? "✓" : "✗"
         )
-        @print last_line_log * EOL
+        println(last_line_log)
+
+        # Find the solution of the subproblem in the logs and make it the new iterate
+        best_evaluation = argmin(data_f)
+        p = data_Rpv[best_evaluation]
 
         # Update remaining evaluations
         remaining_eval_budget -= last_eval
-        termination = true
-        # TODO: Think of changing attributes of the State object!
+
+        termination = get_radius_evaluation(tangent_solver) == 0 || remaining_eval_budget == 0
     end
-
-    return dfros
-end
-
-function DFROSolver(
-        M::AbstractManifold,
-        f,
-        p0;
-        inequality_constraints = void_constraint,
-        solver::AbstractTangentSolver = MADSTangentSolver(),
-        max_evals::Int = 1000 * representation_size(M)[1],
-        stopping_criterion::DFStoppingCriterion = StopRadiusAndBudget(max_evals),
-        retraction_method::AbstractRetractionMethod = default_retraction_method(M),
-        invertibility_bound::AbstractInvertibilityBound = default_invertibility_bound(M, retraction_method),
-        εeqs::Float64 = 1.0e-8
-    )
-    rdfos = DFROState(M, p0, stopping_criterion, retraction_method)
-    mpb = DefaultManoptProblem(M, mco)
-
-    n = representation_size(M)[1]
-    q = manifold_dimension(M)
-    iter::Int = 0
-    n_evals::Int = 0
-    eval_data::Vector{Float64} = fill(typemax(Float64), max_evals)
-    remaining_evals = max_evals
-    processed_solver_details = Dict()
-
-    p = is_point(M, p0; atol = εeqs) ? p0 : project(M, p0)
-    !is_point(M, p; atol = εeqs) && return p, [1.0e20], [], [], [], [], []
-
-    if typeof(solver) == MADSTangentSolver
-        options = Dict()
-        if solver.transfer_mesh_size
-            processed_solver_details = Dict("best_mesh_size" => ones(q))
-        end
-    end
-
-    iterates_history = Matrix{Float64}[]
-    objective_history = Vector{Float64}[]
-    if !isnothing(inequality_constraints)
-        g_history = Matrix{Float64}[]
-    end
-
-    v_history = Matrix{Float64}[]
-    d_history = Matrix{Float64}[]
-    main_iterates = Vector{Float64}[]
-
-    # @printf("| %10s | %10s | %10s | %13s |\n", "iteration", "# evals", "total evals", "f")
-    # @printf("|-%10s-|-%10s-|-%11s-|-%13s-|\n", "-"^10, "-"^10, "-"^10, "-"^14)
-
-
-    while true
-        push!(main_iterates, p)
-        # Construct the subproblem blackbox in ℝ^q.
-        local_blackbox(v) = retract_eval(M, mco, p, v, retraction_method, solver; inequality_constraints = inequality_constraints, εeqs = εeqs) # Will embed v in TpM, then retract this embedding on M and finally evaluate the objective at this retracted point.
-
-        # Compute the injectivity radius, or a lower bound to it.
-        radius = invertibility_radius(M, p, retraction_method, invertibility_bound)
-
-        # Solve the q-dimensional subproblem with the given solver, with stopping criterion being the injectivity radius.
-
-        if typeof(solver) == MADSTangentSolver && solver.transfer_mesh_size
-            options["initial_mesh_size"] = processed_solver_details["best_mesh_size"]
-        end
-
-        try
-            if isnothing(inequality_constraints)
-                solve!(M, p, solver, local_blackbox, radius, remaining_evals; options)
-            else
-                gp = inequality_constraints(p)
-                nb_inequalities = length(gp)
-                init_feasible = all(gp .≤ 0)
-                solve!(M, p, solver, local_blackbox, radius, remaining_evals; options, nb_inequalities = nb_inequalities, init_feasible = init_feasible)
-            end
-        catch e
-            # An error thrown here means that solving the subproblem has failed.
-            # It is most likely due to a Jacobian that does not have full rank at the current iterate.
-            eval_data[1] = get_cost(M, mco, p)
-            return p, eval_data[1:1], iterates_history, objective_history, v_history, d_history
-        end
-
-        if isnothing(inequality_constraints)
-            vs, fs, solver_details = get_subproblem_result(M, solver)
-        else
-            gp = inequality_constraints(p)
-            nb_inequalities = length(gp)
-            vs, fs, gs, solver_details = get_subproblem_result(M, solver; nb_inequalities = nb_inequalities)
-        end
-        # TODO. Check if instead of embedding and evaluating again, the evaluation wrappers (defined in this file) could use global variables to store the data.
-
-        # Embed the vs in ℝ^n
-        ds = vs_to_ds(M, p, vs)
-
-        # Retract the ds on M
-        Rpds = ds_to_Rpds(M, p, ds)
-
-        # Retrieve the costs of all evaluated points
-        fs = vectorized_cost(M, mco, Rpds)
-        stratified_fs = fill(typemax(Float64), length(fs))
-
-        if isnothing(inequality_constraints)
-            best = fs[1]
-            for i in 1:length(stratified_fs)
-                if fs[i] < best
-                    best = fs[i]
-                end
-                stratified_fs[i] = best
-            end
-        else
-            # Retrieve the values of the inequality constraints for all evaluated points
-            gp = inequality_constraints(p)
-            nb_inequalities = length(gp)
-            gs = vectorized_inequalities(inequality_constraints, Rpds, nb_inequalities)
-            feasible_iterates = findall(i -> all(@inbounds(gs[i, j] ≤ 1.0e-8 for j in axes(gs, 2))), axes(gs, 1))
-            feasible_fs = fs[feasible_iterates]
-            best = 1.0e20
-
-            for i in 1:length(stratified_fs)
-                fval = (i in feasible_iterates) ? fs[i] : 1.0e20
-                if fval < best
-                    best = fval
-                end
-                stratified_fs[i] = best
-            end
-        end
-
-        best_f::Float64 = 1.0e20
-        best_eval::Int = 0
-        best_v = zeros(q)
-        best_d = zeros(n)
-        best_p = zeros(n)
-
-        # Retrieve the best point
-        if isnothing(inequality_constraints)
-            best_f, best_eval = findmin(fs)
-            best_v, best_d, best_p = vs[best_eval, :], ds[best_eval, :], Rpds[best_eval, :]
-        else
-            feasible_iterates = findall(i -> all(@inbounds(gs[i, j] ≤ 1.0e-8 for j in axes(gs, 2))), axes(gs, 1))
-            feasible_fs = fs[feasible_iterates]
-            if length(feasible_fs) == 0
-                best_f = 1.0e20
-                best_eval = typemax(Int)
-                best_v, best_d, best_p = fill(typemax(Float64), q), fill(typemax(Float64), n), fill(typemax(Float64), n)
-            else
-                best_f = minimum(feasible_fs)
-                it::Int = 1
-                while fs[it] ≠ best_f || gs[it] > 1.0e-8
-                    it += 1
-                end
-                best_eval = it
-                best_v, best_d, best_p = vs[best_eval, :], ds[best_eval, :], Rpds[best_eval, :]
-            end
-        end
-
-        # Check how many evaluations were actually used
-        used_evals = size(vs)[1]
-
-        # Updates
-        set_tangent_iterate!(rdfos, best_d)
-        set_iterate!(rdfos, best_p)
-        eval_data[(n_evals + 1):(n_evals + used_evals)] .= stratified_fs
-
-        p = best_p
-        iter += 1
-        n_evals += used_evals
-        remaining_evals -= used_evals
-
-        push!(iterates_history, Rpds)
-        push!(objective_history, fs)
-        push!(v_history, vs)
-        push!(d_history, ds)
-        if !isnothing(inequality_constraints)
-            push!(g_history, gs)
-        end
-
-        processed_solver_details = process_details(M, solver, solver_details)
-
-        (norm(p) == typemax(Float64) || !is_point(M, p; atol = εeqs)) && break
-
-        # @printf("| %10d | %10d | %11d | %14e |\n", iter, used_evals, n_evals, best_f)
-        # TODO. Reset internal storage of the tangent solver (after having transferred its data into a global array here).
-        stopping_criterion(mpb, rdfos, iter, n_evals, solver.flag, retraction_method, invertibility_bound) && break
-    end
-    # println("A stopping criterion was met.")
-    return p, eval_data[1:n_evals], iterates_history, objective_history, v_history, d_history, main_iterates
-end
-
-# TODO. Those should go. All of this is within the tangent solver's storage attributes.
-function vs_to_ds(M::AbstractManifold, p, vs)
-    n_evals = size(vs)[1]
-    q = representation_size(M)[1]
-    ds = zeros(Float64, (n_evals, q))
-    n_evals = size(ds)[1]
-    for i in 1:n_evals
-        v = vs[i, :]
-        d = get_vector(M, p, v)
-        ds[i, :] .= d
-    end
-    return ds
-end
-
-function ds_to_Rpds(M::AbstractManifold, p, ds; retraction_method::AbstractRetractionMethod = default_retraction_method(M))
-    Rpds = zeros(Float64, size(ds))
-    n_evals = size(ds)[1]
-    for i in 1:n_evals
-        d = ds[i, :]
-        Rpd = retract(M, p, d, retraction_method)
-        Rpds[i, :] .= Rpd
-    end
-    return Rpds
-end
-
-function vectorized_cost(M::AbstractManifold, mco::AbstractManifoldCostObjective, Rpds)
-    n_evals = size(Rpds)[1]
-    fs = zeros(n_evals)
-    for i in 1:n_evals
-        f = get_cost(M, mco, Rpds[i, :])
-        fs[i] = f
-    end
-    return fs
-end
-
-function vectorized_inequalities(g::Function, Rpds, nb_inequalities::Int)
-    n_evals = size(Rpds)[1]
-    gs = zeros((n_evals, nb_inequalities))
-    for i in 1:n_evals
-        g_val = g(Rpds[i, :])
-        gs[i, :] = g_val
-    end
-    return gs
+    return p
 end

--- a/src/solvers/DFROSolver.jl
+++ b/src/solvers/DFROSolver.jl
@@ -78,8 +78,8 @@ function DFROSolver(
         # First line: display outer_counter and ρ
         if print_level == 1
             first_line_log = @sprintf(
-                " %-10d%-12.6f%-10d%-15.6f%-10s%-20s%-10s",
-                outer_counter, radius, 1, data_f[1], "", data_Rpv[1], is_point(M, data_Rpv[1])
+                " %-10d%-12.6f%-10d%-15.6f%-10s%",
+                outer_counter, radius, 1, data_f[1], ""
             )
             println(first_line_log)
         end
@@ -88,14 +88,14 @@ function DFROSolver(
         if print_level == 1
             for eval in 2:(last_eval - 1)
                 line_log = @sprintf(
-                    " %-10s%-12s%-10d%-15.6f%-10s%-20s%-10s",
-                    "", "", eval, data_f[eval], "", data_Rpv[eval], is_point(M, data_Rpv[eval])
+                    " %-10s%-12s%-10d%-15.6f%-10s",
+                    "", "", eval, data_f[eval], ""
                 )
                 println(line_log)
             end
             last_line_log = @sprintf(
-                " %-10s%-12s%-10d%-15.6f%-10s%-20s%-10s",
-                "", "", last_eval, data_f[last_eval], improvement_outside_radius ? "✓" : "✗", data_Rpv[last_eval], is_point(M, data_Rpv[last_eval])
+                " %-10s%-12s%-10d%-15.6f%-10s",
+                "", "", last_eval, data_f[last_eval], improvement_outside_radius ? "✓" : "✗"
             )
             println(last_line_log)
         end

--- a/src/solvers/DFROSolver.jl
+++ b/src/solvers/DFROSolver.jl
@@ -78,8 +78,8 @@ function DFROSolver(
         # First line: display outer_counter and ρ
         if print_level == 1
             first_line_log = @sprintf(
-                " %-10d%-12.6f%-10d%-15.6f%-10s",
-                outer_counter, radius, 1, data_f[1], ""
+                " %-10d%-12.6f%-10d%-15.6f%-10s%-20s",
+                outer_counter, radius, 1, data_f[1], "", data_Rpv[1]
             )
             println(first_line_log)
         end
@@ -89,13 +89,13 @@ function DFROSolver(
             for eval in 2:(last_eval - 1)
                 line_log = @sprintf(
                     " %-10s%-12s%-10d%-15.6f%-10s%-20s",
-                    "", "", eval, data_f[eval], "", data_d[eval]
+                    "", "", eval, data_f[eval], "", data_Rpv[eval]
                 )
                 println(line_log)
             end
             last_line_log = @sprintf(
-                " %-10s%-12s%-10d%-15.6f%-10s",
-                "", "", last_eval, data_f[last_eval], improvement_outside_radius ? "✓" : "✗"
+                " %-10s%-12s%-10d%-15.6f%-10s%-20s",
+                "", "", last_eval, data_f[last_eval], improvement_outside_radius ? "✓" : "✗", data_Rpv[last_eval]
             )
             println(last_line_log)
         end

--- a/src/solvers/DFROSolver.jl
+++ b/src/solvers/DFROSolver.jl
@@ -28,7 +28,7 @@ function DFROSolver(
         mco::AbstractManifoldCostObjective,
         g,
         p0,
-        m::Int,
+        m::Int;
         tangent_solver::AbstractTangentSolver = MADSTangentSolver(),
         max_evals::Int = 1000 * representation_size(M)[1],
         retraction_method::AbstractRetractionMethod = default_retraction_method(M),
@@ -50,12 +50,12 @@ function DFROSolver(
     println(header)
     println(separator)
 
-    ℓ = 0
+    outer_counter = 0
     p = p0
     remaining_eval_budget = max_evals
     termination::Bool = false
     while !termination
-        ℓ += 1
+        outer_counter += 1
 
         # Compute a lower bound to the invertibility radius at p
         radius = invertibility_radius(M, p; m = retraction_method, ρ = invertibility_bound)
@@ -67,33 +67,34 @@ function DFROSolver(
         data_f = get_data_f(tangent_solver)
         data_Rpv = get_data_Rpv(tangent_solver)
         n_evals = length(data_f)
-        radius_evaluation = tangent_solver.radius_evaluation
-        solved_outside_radius = radius_evaluation > 0
+        radius_evaluation = get_radius_evaluation(tangent_solver)
+        improvement_outside_radius = radius_evaluation > 0
 
         # Print data from the tangent solver
-        # First line: display ℓ and ρ
+        # First line: display outer_counter and ρ
         first_line_log = @sprintf(
             " %-10d%-12.6f%-10d%-15.6f%-10s",
-            ℓ, radius, 1, data_f[1], ""
+            outer_counter, radius, 1, data_f[1], ""
         )
         println(first_line_log)
         # Then, display the rest
-        last_eval = solved_outside_radius ? radius_evaluation : n_evals
+        last_eval = improvement_outside_radius ? radius_evaluation : n_evals
         for eval in 2:(last_eval - 1)
             line_log = @sprintf(
                 " %-10s%-12s%-10d%-15.6f%-10s",
-                "", "", eval, data_f[eval], ""
+                "", "", eval, data_f[eval], "",
             )
             println(line_log)
         end
         last_line_log = @sprintf(
             " %-10s%-12s%-10d%-15.6f%-10s",
-            "", "", last_eval, data_f[last_eval], solved_outside_radius ? "✓" : "✗"
+            "", "", last_eval, data_f[last_eval], improvement_outside_radius ? "✓" : "✗"
         )
         println(last_line_log)
 
         # Find the solution of the subproblem in the logs and make it the new iterate
-        best_evaluation = argmin(data_f)
+        # Be careful: do not look for the best value of f amongst the points that were only virtually evaluated.
+        best_evaluation = argmin(data_f[1:last_eval])
         p = data_Rpv[best_evaluation]
 
         # Update remaining evaluations

--- a/src/solvers/DFROSolver.jl
+++ b/src/solvers/DFROSolver.jl
@@ -28,11 +28,19 @@ function DFROSolver(
     return DFRO(M, mco, p0; inequality_constraints = inequality_constraints, solver = solver, max_evals = max_evals, stopping_criterion = stopping_criterion, retraction_method = retraction_method, invertibility_bound = invertibility_bound, εeqs = εeqs)
 end
 
+"""
+This one will take a `BlackboxProblem` as an input. Highest level in the hierarchy.
+"""
+function DFROSolver(
+
+    )
+end
+
 function DFROSolver(
         M::AbstractManifold,
-        mco::AbstractManifoldCostObjective,
+        f,
         p0;
-        inequality_constraints::Union{Function, Nothing} = nothing,
+        inequality_constraints = void_constraint,
         solver::AbstractTangentSolver = MADSTangentSolver(),
         max_evals::Int = 1000 * representation_size(M)[1],
         stopping_criterion::DFStoppingCriterion = StopRadiusAndBudget(max_evals),

--- a/src/solvers/DFROSolver.jl
+++ b/src/solvers/DFROSolver.jl
@@ -69,6 +69,7 @@ function DFROSolver(
         # Retrieve data from the tangent solver
         data_f = get_data_f(tangent_solver)
         data_Rpv = get_data_Rpv(tangent_solver)
+        data_d = get_data_d(tangent_solver)
         n_evals = length(data_f)
         radius_evaluation = get_radius_evaluation(tangent_solver)
         improvement_outside_radius = radius_evaluation > 0
@@ -87,8 +88,8 @@ function DFROSolver(
         if print_level == 1
             for eval in 2:(last_eval - 1)
                 line_log = @sprintf(
-                    " %-10s%-12s%-10d%-15.6f%-10s",
-                    "", "", eval, data_f[eval], "",
+                    " %-10s%-12s%-10d%-15.6f%-10s%-20s",
+                    "", "", eval, data_f[eval], "", data_d[eval]
                 )
                 println(line_log)
             end

--- a/src/solvers/tangent_solvers/MADSTangentSolver.jl
+++ b/src/solvers/tangent_solvers/MADSTangentSolver.jl
@@ -69,7 +69,6 @@ function solve!(
     q = manifold_dimension(M)
 
     for budget in (10, max_evals)
-        println("Solving objective $(mco) on manifold $(M)")
         budget > max_evals && continue
 
         clear_tangent_solver!(MTS) # Very important! The storage should be cleared before solving, to prevent duplicates.

--- a/src/solvers/tangent_solvers/MADSTangentSolver.jl
+++ b/src/solvers/tangent_solvers/MADSTangentSolver.jl
@@ -69,6 +69,7 @@ function solve!(
     q = manifold_dimension(M)
 
     for budget in (10, max_evals)
+        println("Solving objective $(mco) on manifold $(M)")
         budget > max_evals && continue
 
         clear_tangent_solver!(MTS) # Very important! The storage should be cleared before solving, to prevent duplicates.

--- a/src/solvers/tangent_solvers/MADSTangentSolver.jl
+++ b/src/solvers/tangent_solvers/MADSTangentSolver.jl
@@ -85,9 +85,9 @@ function solve!(
 
         problem = _build_nomad_problem(MTS.barrier, q, n_ineqs, bb, nomad_options)
 
-        redirect_to_files(MTS.log_path) do # TODO. Is it even useful to redirect to external files if the tangent solver object stores everything?
-            result = solve(problem, zeros(q))
-        end
+        # redirect_to_files(MTS.log_path) do # TODO. Is it even useful to redirect to external files if the tangent solver object stores everything?
+        result = solve(problem, zeros(q))
+        # end
 
         # Check if an improving solution was found outside of the invertibility radius. If so, break and discard the remainder from the storage: these evaluations should not exist.
 

--- a/src/solvers/tangent_solvers/MADSTangentSolver.jl
+++ b/src/solvers/tangent_solvers/MADSTangentSolver.jl
@@ -40,7 +40,7 @@ MADSTangentSolver() = MADSTangentSolver("./tmp.log", 0, ExtremeBarrier(), Vector
 MADSTangentSolver(log_path::String) = MADSTangentSolver(log_path, 0, ExtremeBarrier(), Vector{Float64}[], Float64[], Vector{Float64}[])
 
 set_log_path!(MS::MADSTangentSolver, s::String) = MS.log_path = s
-set_radius_evaluation!(MS::MADSTangentSolver, val::Int) = MS.radius_flag = val
+set_radius_evaluation!(MS::MADSTangentSolver, val::Int) = MS.radius_evaluation = val
 
 function _build_nomad_problem(B::ExtremeBarrier, q::Int, n_ineqs::Int, bb, nomad_options::NOMAD.NomadOptions)
     problem = NOMAD.NomadProblem(q, 1 + n_ineqs, [["OBJ"] ; ["EB" for _ in 1:n_ineqs]], bb; options = nomad_options)
@@ -62,7 +62,7 @@ function solve!(
         M::AbstractManifold,
         p,
         R::AbstractRetractionMethod,
-        radius::Float64,
+        invertibility_radius::Float64,
         n_ineqs::Int;
         g = nothing, max_evals::Int = 1000 * manifold_dimension(M), εeqs::Float64 = 1.0e-8
     )
@@ -96,7 +96,7 @@ function solve!(
             for id_eval in eachindex(MTS.data_d)
                 if (MTS.data_f[id_eval] < best_feasible_f) && (all(MTS.data_g[id_eval] .≤ 0.0)) # Basic strategy: a solution is considered good enough to interrupt if it is feasible and f is improving.
                     best_feasible_f = MTS.data_f[id_eval]
-                    if norm(MTS.data_d[id_eval]) ≥ radius
+                    if norm(MTS.data_d[id_eval]) ≥ invertibility_radius
                         set_radius_evaluation!(MTS, id_eval)
                         break
                     end
@@ -106,7 +106,7 @@ function solve!(
             for id_eval in eachindex(MTS.data_d)
                 if MTS.data_f[id_eval] < best_feasible_f
                     best_feasible_f = MTS.data_f[id_eval]
-                    if norm(MTS.data_d[id_eval]) ≥ radius
+                    if norm(MTS.data_d[id_eval]) ≥ invertibility_radius
                         set_radius_evaluation!(MTS, id_eval)
                         break
                     end
@@ -114,7 +114,7 @@ function solve!(
             end
         end
 
-        MT.radius_evaluation > 0 && break
+        MTS.radius_evaluation > 0 && break
     end
     return MTS
 end

--- a/src/solvers/tangent_solvers/MADSTangentSolver.jl
+++ b/src/solvers/tangent_solvers/MADSTangentSolver.jl
@@ -40,8 +40,7 @@ MADSTangentSolver() = MADSTangentSolver("./tmp.log", false, ExtremeBarrier(), Ve
 MADSTangentSolver(log_path::String) = MADSTangentSolver(log_path, false, ExtremeBarrier(), Vector{Float64}[], Float64[], Vector{Float64}[])
 
 set_log_path!(MS::MADSTangentSolver, s::String) = MS.log_path = s
-set_last_eval!(MS::MADSTangentSolver, eval::Int) = MS.last_eval = eval
-set_flag!(MS::MADSTangentSolver, val::Bool) = MS.flag = val
+set_flag!(MS::MADSTangentSolver, val::Bool) = MS.radius_flag = val
 
 function _build_nomad_problem(B::ExtremeBarrier, q::Int, n_ineqs::Int, bb, nomad_options::NOMAD.NomadOptions)
     problem = NOMAD.NomadProblem(q, 1 + n_ineqs, [["OBJ"] ; ["EB" for _ in 1:n_ineqs]], bb; options = nomad_options)

--- a/src/solvers/tangent_solvers/MADSTangentSolver.jl
+++ b/src/solvers/tangent_solvers/MADSTangentSolver.jl
@@ -28,7 +28,7 @@ Note: the implementation makes use of the interface to the NOMAD 3 software offe
 """
 mutable struct MADSTangentSolver <: AbstractTangentSolver
     log_path::String
-    radius_flag::Bool
+    radius_evaluation::Int
     barrier::AbstractNOMADBarrierType
     data_d::Vector{Vector{Float64}}
     data_Rpv::Vector{Vector{Float64}}
@@ -36,11 +36,11 @@ mutable struct MADSTangentSolver <: AbstractTangentSolver
     data_g::Vector{Vector{Float64}}
 end
 
-MADSTangentSolver() = MADSTangentSolver("./tmp.log", false, ExtremeBarrier(), Vector{Float64}[], Vector{Float64}[], Float64[], Vector{Float64}[])
-MADSTangentSolver(log_path::String) = MADSTangentSolver(log_path, false, ExtremeBarrier(), Vector{Float64}[], Float64[], Vector{Float64}[])
+MADSTangentSolver() = MADSTangentSolver("./tmp.log", 0, ExtremeBarrier(), Vector{Float64}[], Vector{Float64}[], Float64[], Vector{Float64}[])
+MADSTangentSolver(log_path::String) = MADSTangentSolver(log_path, 0, ExtremeBarrier(), Vector{Float64}[], Float64[], Vector{Float64}[])
 
 set_log_path!(MS::MADSTangentSolver, s::String) = MS.log_path = s
-set_flag!(MS::MADSTangentSolver, val::Bool) = MS.radius_flag = val
+set_radius_evaluation!(MS::MADSTangentSolver, val::Int) = MS.radius_flag = val
 
 function _build_nomad_problem(B::ExtremeBarrier, q::Int, n_ineqs::Int, bb, nomad_options::NOMAD.NomadOptions)
     problem = NOMAD.NomadProblem(q, 1 + n_ineqs, [["OBJ"] ; ["EB" for _ in 1:n_ineqs]], bb; options = nomad_options)
@@ -62,17 +62,16 @@ function solve!(
         M::AbstractManifold,
         p,
         R::AbstractRetractionMethod,
-        ρ::AbstractInvertibilityBound,
+        radius::Float64,
         n_ineqs::Int;
         g = nothing, max_evals::Int = 1000 * manifold_dimension(M), εeqs::Float64 = 1.0e-8
     )
     q = manifold_dimension(M)
-    radius = invertibility_radius(M, p; m = R, ρ = ρ)
 
     for budget in (10, max_evals)
         budget > max_evals && continue
 
-        clear_storage!(MTS) # Very important! The storage should be cleared before solving, to prevent duplicates.
+        clear_tangent_solver!(MTS) # Very important! The storage should be cleared before solving, to prevent duplicates.
 
         # Set display format in the NOMAD history file
         if n_ineqs > 0
@@ -92,15 +91,13 @@ function solve!(
 
         # Check if an improving solution was found outside of the invertibility radius. If so, break and discard the remainder from the storage: these evaluations should not exist.
 
-        n_evals = length(MTS.data_d)
-        improving_outside_radius::Bool = false
         best_feasible_f = MTS.data_f[1]
         if n_ineqs > 0
             for id_eval in eachindex(MTS.data_d)
                 if (MTS.data_f[id_eval] < best_feasible_f) && (all(MTS.data_g[id_eval] .≤ 0.0)) # Basic strategy: a solution is considered good enough to interrupt if it is feasible and f is improving.
                     best_feasible_f = MTS.data_f[id_eval]
                     if norm(MTS.data_d[id_eval]) ≥ radius
-                        improving_outside_radius = true
+                        set_radius_evaluation!(MTS, id_eval)
                         break
                     end
                 end
@@ -110,15 +107,14 @@ function solve!(
                 if MTS.data_f[id_eval] < best_feasible_f
                     best_feasible_f = MTS.data_f[id_eval]
                     if norm(MTS.data_d[id_eval]) ≥ radius
-                        improving_outside_radius = true
+                        set_radius_evaluation!(MTS, id_eval)
                         break
                     end
                 end
             end
         end
 
-        MTS.radius_flag = improving_outside_radius
-        improving_outside_radius && break
+        MT.radius_evaluation > 0 && break
     end
     return MTS
 end

--- a/src/solvers/tangent_solvers/TangentSolver.jl
+++ b/src/solvers/tangent_solvers/TangentSolver.jl
@@ -67,7 +67,6 @@ function retract_eval_store!(
 
         return eval_data
     catch e
-        throw(e)
         Rpv = p
         fRpv = FAILURE_MAX
         if n_ineqs > 0

--- a/src/solvers/tangent_solvers/TangentSolver.jl
+++ b/src/solvers/tangent_solvers/TangentSolver.jl
@@ -56,21 +56,30 @@ function retract_eval_store!(
     try
         Rpv = retract(M, p, d, R)
         fRpv = is_point_dispatcher(M, Rpv; tol_eqs = εeqs) ? get_cost(M, mco, Rpv) : FAILURE_MAX
+        if n_ineqs > 0
+            gRpv = g(Rpv)
+        else
+            gRpv = Float64[]
+        end
+        eval_data = BlackboxTangentData(d, Rpv, fRpv, gRpv)
+
+        _store_eval_data!(TS, eval_data)
+
+        return eval_data
     catch e
+        Rpv = p
         fRpv = FAILURE_MAX
+        if n_ineqs > 0
+            gRpv = fill(FAILURE_MAX, n_ineqs)
+        else
+            gRpv = Float64[]
+        end
+        eval_data = BlackboxTangentData(d, Rpv, fRpv, gRpv)
+
+        _store_eval_data!(TS, eval_data)
+
+        return eval_data
     end
-
-    if n_ineqs > 0
-        gRpv = g(Rpv)
-    else
-        gRpv = Float64[]
-    end
-
-    eval_data = BlackboxTangentData(d, Rpv, fRpv, gRpv)
-
-    _store_eval_data!(TS, eval_data)
-
-    return eval_data
 end
 
 """

--- a/src/solvers/tangent_solvers/TangentSolver.jl
+++ b/src/solvers/tangent_solvers/TangentSolver.jl
@@ -55,7 +55,7 @@ function retract_eval_store!(
     d = get_vector(M, p, v, DefaultOrthonormalBasis())
     Rpv = retract(M, p, d, R)
 
-    fRpv = is_point(M, Rpv; tol_eqs = εeqs) ? get_cost(M, mco, Rpv) : FAILURE_MAX
+    fRpv = is_point_dispatcher(M, Rpv; tol_eqs = εeqs) ? get_cost(M, mco, Rpv) : FAILURE_MAX
 
     if n_ineqs > 0
         gRpv = g(Rpv)
@@ -99,7 +99,7 @@ function blackbox_wrapper_store!(
 end
 
 """
-    solve!(TS::AbstractTangentSolver, f, M::AbstractManifold, p, R::AbstractRetractionMethod, ρ::AbstractInvertibilityBound; g)
+    solve!(TS::AbstractTangentSolver, mco::AbstractManifoldCostObjective, M::AbstractManifold, p, R::AbstractRetractionMethod, ρ::AbstractInvertibilityBound; g)
 
 Solve the subproblem
 
@@ -116,7 +116,7 @@ A history of all tangent iterates, associated retractions and (`f`,`g`) values i
 """
 function solve!(
         TS::AbstractTangentSolver,
-        f,
+        mco::AbstractManifoldCostObjective,
         M::AbstractManifold,
         p,
         R::AbstractRetractionMethod,

--- a/src/solvers/tangent_solvers/TangentSolver.jl
+++ b/src/solvers/tangent_solvers/TangentSolver.jl
@@ -21,7 +21,7 @@ get_data_d(TS::AbstractTangentSolver) = TS.data_d
 get_data_Rpv(TS::AbstractTangentSolver) = TS.data_Rpv
 get_data_f(TS::AbstractTangentSolver) = TS.data_f
 get_data_g(TS::AbstractTangentSolver) = TS.data_g
-get_radius_flag(TS::AbstractTangentSolver) = TS.radius_flag
+get_radius_evaluation(TS::AbstractTangentSolver) = TS.radius_evaluation
 
 function _store_eval_data!(TS::AbstractTangentSolver, eval_data::BlackboxTangentData)
     println(length(TS.data_d))
@@ -55,7 +55,7 @@ function retract_eval_store!(
     d = get_vector(M, p, v, DefaultOrthonormalBasis())
     Rpv = retract(M, p, d, R)
 
-    fRpv = is_point(M, Rpv; atol = εeqs) ? get_cost(M, mco, Rpv) : FAILURE_MAX
+    fRpv = is_point(M, Rpv; tol_eqs = εeqs) ? get_cost(M, mco, Rpv) : FAILURE_MAX
 
     if n_ineqs > 0
         gRpv = g(Rpv)
@@ -120,7 +120,7 @@ function solve!(
         M::AbstractManifold,
         p,
         R::AbstractRetractionMethod,
-        ρ::AbstractInvertibilityBound,
+        invertibility_radius::Float64,
         n_ineqs::Int;
         g, max_evals::Int, εeqs::Float64 = 1.0e-8
     )

--- a/src/solvers/tangent_solvers/TangentSolver.jl
+++ b/src/solvers/tangent_solvers/TangentSolver.jl
@@ -52,21 +52,34 @@ function retract_eval_store!(
         εeqs::Float64 = 1.0e-8
     )
     d = get_vector(M, p, v, DefaultOrthonormalBasis())
-    Rpv = retract(M, p, d, R)
 
-    fRpv = is_point_dispatcher(M, Rpv; tol_eqs = εeqs) ? get_cost(M, mco, Rpv) : FAILURE_MAX
+    try
+        Rpv = retract(M, p, d, R)
+        fRpv = is_point_dispatcher(M, Rpv; tol_eqs = εeqs) ? get_cost(M, mco, Rpv) : FAILURE_MAX
+        if n_ineqs > 0
+            gRpv = g(Rpv)
+        else
+            gRpv = Float64[]
+        end
+        eval_data = BlackboxTangentData(d, Rpv, fRpv, gRpv)
 
-    if n_ineqs > 0
-        gRpv = g(Rpv)
-    else
-        gRpv = Float64[]
+        _store_eval_data!(TS, eval_data)
+
+        return eval_data
+    catch e
+        Rpv = p
+        fRpv = FAILURE_MAX
+        if n_ineqs > 0
+            gRpv = fill(FAILURE_MAX, n_ineqs)
+        else
+            gRpv = Float64[]
+        end
+        eval_data = BlackboxTangentData(d, Rpv, fRpv, gRpv)
+
+        _store_eval_data!(TS, eval_data)
+
+        return eval_data
     end
-
-    eval_data = BlackboxTangentData(d, Rpv, fRpv, gRpv)
-
-    _store_eval_data!(TS, eval_data)
-
-    return eval_data
 end
 
 """

--- a/src/solvers/tangent_solvers/TangentSolver.jl
+++ b/src/solvers/tangent_solvers/TangentSolver.jl
@@ -67,6 +67,7 @@ function retract_eval_store!(
 
         return eval_data
     catch e
+        throw(e)
         Rpv = p
         fRpv = FAILURE_MAX
         if n_ineqs > 0

--- a/src/solvers/tangent_solvers/TangentSolver.jl
+++ b/src/solvers/tangent_solvers/TangentSolver.jl
@@ -52,9 +52,13 @@ function retract_eval_store!(
         εeqs::Float64 = 1.0e-8
     )
     d = get_vector(M, p, v, DefaultOrthonormalBasis())
-    Rpv = retract(M, p, d, R)
 
-    fRpv = is_point_dispatcher(M, Rpv; tol_eqs = εeqs) ? get_cost(M, mco, Rpv) : FAILURE_MAX
+    try
+        Rpv = retract(M, p, d, R)
+        fRpv = is_point_dispatcher(M, Rpv; tol_eqs = εeqs) ? get_cost(M, mco, Rpv) : FAILURE_MAX
+    catch e
+        fRpv = FAILURE_MAX
+    end
 
     if n_ineqs > 0
         gRpv = g(Rpv)

--- a/src/solvers/tangent_solvers/TangentSolver.jl
+++ b/src/solvers/tangent_solvers/TangentSolver.jl
@@ -24,7 +24,6 @@ get_data_g(TS::AbstractTangentSolver) = TS.data_g
 get_radius_evaluation(TS::AbstractTangentSolver) = TS.radius_evaluation
 
 function _store_eval_data!(TS::AbstractTangentSolver, eval_data::BlackboxTangentData)
-    println(length(TS.data_d))
     push!(TS.data_d, eval_data.d)
     push!(TS.data_Rpv, eval_data.p)
     push!(TS.data_f, eval_data.f)

--- a/src/solvers/tangent_solvers/TangentSolver.jl
+++ b/src/solvers/tangent_solvers/TangentSolver.jl
@@ -32,11 +32,12 @@ function _store_eval_data!(TS::AbstractTangentSolver, eval_data::BlackboxTangent
     return TS
 end
 
-function clear_storage!(TS::AbstractTangentSolver)
+function clear_tangent_solver!(TS::AbstractTangentSolver)
     TS.data_d = Vector{Float64}[]
     TS.data_Rpv = Vector{Float64}[]
     TS.data_f = Float64[]
     TS.data_g = Vector{Float64}[]
+    set_radius_evaluation!(TS, 0)
     return TS
 end
 

--- a/src/solvers/tangent_solvers/TangentSolver.jl
+++ b/src/solvers/tangent_solvers/TangentSolver.jl
@@ -52,21 +52,33 @@ function retract_eval_store!(
         εeqs::Float64 = 1.0e-8
     )
     d = get_vector(M, p, v, DefaultOrthonormalBasis())
-    Rpv = retract(M, p, d, R)
+    try
+        Rpv = retract(M, p, d, R)
+        fRpv = is_point_dispatcher(M, Rpv; tol_eqs = εeqs) ? get_cost(M, mco, Rpv) : FAILURE_MAX
+        if n_ineqs > 0
+            gRpv = g(Rpv)
+        else
+            gRpv = Float64[]
+        end
+        eval_data = BlackboxTangentData(d, Rpv, fRpv, gRpv)
 
-    fRpv = is_point_dispatcher(M, Rpv; tol_eqs = εeqs) ? get_cost(M, mco, Rpv) : FAILURE_MAX
+        _store_eval_data!(TS, eval_data)
 
-    if n_ineqs > 0
-        gRpv = g(Rpv)
-    else
-        gRpv = Float64[]
+        return eval_data
+    catch e
+        Rpv = p
+        fRpv = FAILURE_MAX
+        if n_ineqs > 0
+            gRpv = fill(FAILURE_MAX, n_ineqs)
+        else
+            gRpv = Float64[]
+        end
+        eval_data = BlackboxTangentData(d, Rpv, fRpv, gRpv)
+
+        _store_eval_data!(TS, eval_data)
+
+        return eval_data
     end
-
-    eval_data = BlackboxTangentData(d, Rpv, fRpv, gRpv)
-
-    _store_eval_data!(TS, eval_data)
-
-    return eval_data
 end
 
 """

--- a/src/solvers/tangent_solvers/TangentSolver.jl
+++ b/src/solvers/tangent_solvers/TangentSolver.jl
@@ -52,34 +52,21 @@ function retract_eval_store!(
         εeqs::Float64 = 1.0e-8
     )
     d = get_vector(M, p, v, DefaultOrthonormalBasis())
+    Rpv = retract(M, p, d, R)
 
-    try
-        Rpv = retract(M, p, d, R)
-        fRpv = is_point_dispatcher(M, Rpv; tol_eqs = εeqs) ? get_cost(M, mco, Rpv) : FAILURE_MAX
-        if n_ineqs > 0
-            gRpv = g(Rpv)
-        else
-            gRpv = Float64[]
-        end
-        eval_data = BlackboxTangentData(d, Rpv, fRpv, gRpv)
+    fRpv = is_point_dispatcher(M, Rpv; tol_eqs = εeqs) ? get_cost(M, mco, Rpv) : FAILURE_MAX
 
-        _store_eval_data!(TS, eval_data)
-
-        return eval_data
-    catch e
-        Rpv = p
-        fRpv = FAILURE_MAX
-        if n_ineqs > 0
-            gRpv = fill(FAILURE_MAX, n_ineqs)
-        else
-            gRpv = Float64[]
-        end
-        eval_data = BlackboxTangentData(d, Rpv, fRpv, gRpv)
-
-        _store_eval_data!(TS, eval_data)
-
-        return eval_data
+    if n_ineqs > 0
+        gRpv = g(Rpv)
+    else
+        gRpv = Float64[]
     end
+
+    eval_data = BlackboxTangentData(d, Rpv, fRpv, gRpv)
+
+    _store_eval_data!(TS, eval_data)
+
+    return eval_data
 end
 
 """

--- a/src/types/DFROState.jl
+++ b/src/types/DFROState.jl
@@ -7,7 +7,7 @@
 * `p` is the current iterate on the manifold.
 * `d` is the current best tangent vector found at ``T_p\\mathcal{M}``.
 """
-mutable struct DFROState{P, SC <: StoppingCriterion} <: AbstractManoptSolverState
+mutable struct DFROState{P, SC <: DFStoppingCriterion} <: AbstractManoptSolverState
     p::P
     d::P
     stop::SC

--- a/src/types/DFROState.jl
+++ b/src/types/DFROState.jl
@@ -25,6 +25,10 @@ function DFROState(
     return DFROState{P, SC}(p, zeros(representation_size(M)), stopping_criterion)
 end
 
+function DFROState(M::AbstractManifold, p::P) where {P}
+    return DFROState(p, zeros(representation_size(M)[1]), StopRadiusAndBudget(1000 * representation_size(M)[1]))
+end
+
 set_iterate!(s::DFROState, p) = s.p = p
 set_tangent_iterate!(s::DFROState, d) = s.d = d
 

--- a/src/types/DFROState.jl
+++ b/src/types/DFROState.jl
@@ -13,18 +13,6 @@ mutable struct DFROState{P, SC <: DFStoppingCriterion} <: AbstractManoptSolverSt
     stop::SC
 end
 
-function DFROState(
-        M::AbstractManifold,
-        p::P,
-        stopping_criterion::SC = StopWhenWithinRadius(),
-        retraction_method::AbstractRetractionMethod = default_retraction_method(M)
-    ) where {
-        P,
-        SC <: DFStoppingCriterion,
-    }
-    return DFROState{P, SC}(p, zeros(representation_size(M)), stopping_criterion)
-end
-
 function DFROState(M::AbstractManifold, p::P) where {P}
     return DFROState(p, zeros(representation_size(M)[1]), StopRadiusAndBudget(1000 * representation_size(M)[1]))
 end

--- a/src/types/EqualityManifold.jl
+++ b/src/types/EqualityManifold.jl
@@ -78,11 +78,11 @@ function check_size(M::EqualityManifold, p, X)
     end
 end
 
-function check_point(M::EqualityManifold, p; kwargs...)
+function check_point(M::EqualityManifold, p; tol_eqs::Float64 = 1.0e-8)
     s = check_size(M, p)
     isnothing(s) || return s
     h = eval_defining_function(M, p)
-    if !all(isapprox.(h, 0.0; kwargs...))
+    if !all(isapprox.(h, 0.0; atol = tol_eqs))
         return DomainError(
             h,
             "The point $(p) does not lie on the $(M): h(p)=$(h)."
@@ -91,12 +91,12 @@ function check_point(M::EqualityManifold, p; kwargs...)
     return nothing
 end
 
-function check_vector(M::EqualityManifold, p, X; kwargs...)
-    s = check_point(M, p)
+function check_vector(M::EqualityManifold, p, X; tol_tangent::Float64 = 1.0e-12, kwargs...)
+    s = check_point(M, p; kwargs...)
     isnothing(s) || return s
     Jhp = eval_defining_jacobian(M, p)
     JhpX = Jhp * X
-    if !all(isapprox.(JhpX, 0.0; kwargs...))
+    if !all(isapprox.(JhpX, 0.0; atol = tol_tangent))
         return DomainError(
             Jhp * X,
             "The vector $(X) is not tangent to $(M) at $(p) since its product with the Jacobian has value $(JhpX)."
@@ -155,8 +155,8 @@ end
 
 default_retraction_method(::EqualityManifold) = ProjectionRetraction()
 
-function retract_project!(M::EqualityManifold, q, p, X)
-    if !is_vector(M, p, X)
+function retract_project!(M::EqualityManifold, q, p, X; kwargs...)
+    if !is_vector(M, p, X; kwargs...)
         throw(DomainError("Vector $(X) is not a tangent vector to $(M) at $(p). It can not be retracted."))
     end
     pX = p .+ X

--- a/src/types/ScaledSphere.jl
+++ b/src/types/ScaledSphere.jl
@@ -70,7 +70,6 @@ end
 default_invertibility_bound(M::ScaledSphere, m::ExponentialRetraction) = ExactInvertibility()
 ManifoldsBase.injectivity_radius(M::ScaledSphere) = π * get_radius(M)
 ManifoldsBase.injectivity_radius(M::ScaledSphere, p, m::ExponentialRetraction) = π * get_radius(M)
-invertibility_radius(M::ScaledSphere, p, m::ExponentialRetraction, b::ExactInvertibility) = injectivity_radius(M, p, m)
 
 # Logarithmic map
 function ManifoldsBase.log!(M::ScaledSphere, X, p, q)

--- a/src/types/checks_dispatchers.jl
+++ b/src/types/checks_dispatchers.jl
@@ -1,0 +1,6 @@
+# These dispatchers are meant to patch the impossibility for `is_point` in `ManifoldsBase` to use a tolerance.
+
+function is_point_dispatcher(M::AbstractManifold, p; tol_eqs::Float64 = 1.0e-8) end
+
+is_point_dispatcher(M::Sphere, p; tol_eqs::Float64 = 1.0e-8) = is_point(M, p)
+is_point_dispatcher(M::EqualityManifold, p; tol_eqs::Float64 = 1.0e-8) = is_point(M, p; tol_eqs = tol_eqs)

--- a/src/types/invertibility.jl
+++ b/src/types/invertibility.jl
@@ -92,8 +92,7 @@ function invertibility_radius(M::AbstractManifold, p; m::AbstractRetractionMetho
     return _invertibility_radius(M, p, m, ρ)
 end
 
-_invertibility_radius(M::AbstractManifold, p, m::ExponentialRetraction, ρ::ExactInvertibility) = injectivity_radius(M, p)
-_invertibility_radius(M::Sphere, p, m::StabilizedRetraction, ρ::ExactInvertibility) = Float64(injectivity_radius(M, p))
+_invertibility_radius(M::AbstractManifold, p, m::AbstractRetractionMethod, ρ::ExactInvertibility) = Float64(injectivity_radius(M, p, m))
 
 function _invertibility_radius(M::EqualityManifold, p, m::ProjectionRetraction, ρ::OneOverSpectral)
     Hhis = eval_defining_hessians(M, p)

--- a/src/types/invertibility.jl
+++ b/src/types/invertibility.jl
@@ -93,7 +93,7 @@ function invertibility_radius(M::AbstractManifold, p; m::AbstractRetractionMetho
 end
 
 _invertibility_radius(M::AbstractManifold, p, m::ExponentialRetraction, ρ::ExactInvertibility) = injectivity_radius(M, p)
-_invertibility_radius(M::Sphere, p, m::StabilizedRetraction, ρ::ExactInvertibility) = injectivity_radius(M, p)
+_invertibility_radius(M::Sphere, p, m::StabilizedRetraction, ρ::ExactInvertibility) = Float64(injectivity_radius(M, p))
 
 function _invertibility_radius(M::EqualityManifold, p, m::ProjectionRetraction, ρ::OneOverSpectral)
     Hhis = eval_defining_hessians(M, p)

--- a/src/utils/void_constraint.jl
+++ b/src/utils/void_constraint.jl
@@ -1,1 +1,0 @@
-void_constraint(::Any) = Float64[]

--- a/src/utils/void_constraint.jl
+++ b/src/utils/void_constraint.jl
@@ -1,0 +1,1 @@
+void_constraint(::Any) = Float64[]

--- a/test/DFROSolver.jl
+++ b/test/DFROSolver.jl
@@ -36,10 +36,4 @@
 
     @test is_point(M1, res5)
     @test f3(res5) < 2.45e-1
-
-    # Test where numerical instabilities occur
-    h4(p) = [abs(p[1]) - p[2]]
-    M4 = EqualityManifold(h4, 1, 2)
-    p3 = [-4.0, 4.0]
-    res6 = DFROSolver(M4, f2, g1)
 end

--- a/test/DFROSolver.jl
+++ b/test/DFROSolver.jl
@@ -1,0 +1,45 @@
+@testset "DFRO Solver" begin
+    M1 = Sphere(2)
+    f1(p) = p[1]
+    g1(p) = []
+    p1 = [1.0, 0.0, 0.0]
+    res1 = DFROSolver(M1, f1, g1, p1, 0; print_level = 0)
+
+    @test is_point(M1, res1)
+    @test isapprox(f1(res1), -1.0)
+
+    res2 = DFROSolver(M1, f1, g1, p1, 0; retraction_method = ProjectionRetraction(), print_level = 0)
+
+    @test is_point(M1, res2)
+    @test isapprox(f1(res2), -1.0)
+
+    h2(p) = [sum(p .^ 2) - 1] # Don't use norm(p)^2 because the operator is not supported by MathOptInterface
+    M2 = EqualityManifold(h2, 2, 3)
+    res3 = DFROSolver(M2, f1, g1, p1, 0; print_level = 0)
+
+    @test is_point(M2, res3)
+    @test isapprox(f1(res3), -1.0)
+
+    # On a parabola
+    h3(p) = [p[1]^2 - p[2]]
+    M3 = EqualityManifold(h3, 1, 2)
+    p2 = [2.0, 4.0]
+    f2(p) = p[2]
+    res4 = DFROSolver(M3, f2, g1, p2, 0; print_level = 0)
+
+    @test is_point(M3, res4)
+    @test isapprox(f1(res4), 0.0; atol = 1.0e-4)
+
+    # With Rosenbrock
+    f3(p) = 100 * (p[2] - p[1]^2)^2 + (1 - p[1])^2 + 100 * (p[3] - p[2]^2)^2 + (1 - p[2])^2
+    res5 = DFROSolver(M1, f3, g1, p1, 0; print_level = 0)
+
+    @test is_point(M1, res5)
+    @test f3(res5) < 2.45e-1
+
+    # Test where numerical instabilities occur
+    h4(p) = [abs(p[1]) - p[2]]
+    M4 = EqualityManifold(h4, 1, 2)
+    p3 = [-4.0, 4.0]
+    res6 = DFROSolver(M4, f2, g1)
+end

--- a/test/DFROSolver.jl
+++ b/test/DFROSolver.jl
@@ -15,7 +15,7 @@
 
     h2(p) = [sum(p .^ 2) - 1] # Don't use norm(p)^2 because the operator is not supported by MathOptInterface
     M2 = EqualityManifold(h2, 2, 3)
-    res3 = DFROSolver(M2, f1, g1, p1, 0; print_level = 0)
+    res3 = DFROSolver(M2, f1, g1, p1, 0; print_level = 1)
 
     @test is_point(M2, res3)
     @test isapprox(f1(res3), -1.0)

--- a/test/EqualityManifold.jl
+++ b/test/EqualityManifold.jl
@@ -9,9 +9,9 @@
     p2 = [2.1, 0.0, 0.0]
     p3 = [2.0, 2.0]
 
-    @test is_point(M1, p1)
-    @test !is_point(M1, p2)
-    @test !is_point(M1, p3)
+    @test is_point_dispatcher(M1, p1)
+    @test !is_point_dispatcher(M1, p2)
+    @test !is_point_dispatcher(M1, p3)
 
     X1 = [0.0, 1.0, 1.0]
     X2 = [0.0, 0.0]
@@ -39,16 +39,15 @@
     X6 = [3.0, 2.0]
     X7 = [3.001, 2.0]
     X8 = [3 * (0.01)^(2 / 3), 0.2]
-    @test is_point(M2, p4; atol = 1.0e-12)
-    @test is_point(M2, p5; atol = 1.0e-12)
-    @test is_vector(M2, p4, X6; atol = 1.0e-12)
-    @test !is_vector(M2, p4, X7; atol = 1.0e-12)
-    @test is_vector(M2, p5, X8; atol = 1.0e-12)
+    @test is_point_dispatcher(M2, p4; tol_eqs = 1.0e-12)
+    @test is_point_dispatcher(M2, p5; tol_eqs = 1.0e-12)
+    @test is_vector(M2, p4, X6; tol_eqs = 1.0e-12)
+    @test !is_vector(M2, p4, X7; tol_eqs = 1.0e-12)
+    @test is_vector(M2, p5, X8; tol_eqs = 1.0e-12)
 
     @test_throws Any get_basis(M2, p6, DefaultOrthonormalBasis())
 
     # Random point generation
     p4 = rand(M1)
-    @test is_point(M1, p4; atol = 1.0e-12)
-
+    @test is_point_dispatcher(M1, p4; tol_eqs = 1.0e-12)
 end

--- a/test/StoppingCriteria.jl
+++ b/test/StoppingCriteria.jl
@@ -15,7 +15,7 @@ using Manopt:
     sc1 = StopAfterEvaluation(10000)
     em = FractionEvalManager(10000, 0.1)
     @test get_reason(sc1) == ""
-    s = DFROState(M, p, sc1, ProjectionRetraction())
+    s = DFROState(M, p)
     @test !sc1(pb, s, 0, 0)
     @test sc1(pb, s, 0, 10000)
 

--- a/test/TangentSolver.jl
+++ b/test/TangentSolver.jl
@@ -1,31 +1,33 @@
-@testset "TangentSolver" begin
+@testset "Tangent Solver" begin
     M = Sphere(2)
     p1 = [1.0, 0.0, 0.0]
     cost(M, p) = sum(p)
     mco = ManifoldCostObjective(cost)
     MTS = MADSTangentSolver()
+    radius1 = invertibility_radius(M, p1)
     solve!(
         MTS,
         mco,
         M,
         p1,
         StabilizedRetraction(),
-        ExactInvertibility(),
+        radius1,
         0
     )
-    @test get_radius_flag(MTS)
+    @test get_radius_evaluation(MTS) > 0
     @test length(get_data_d(MTS)) == 10
     @test length(get_data_f(MTS)) == 10
     @test length(get_data_g(MTS)) == 0
     @test length(get_data_Rpv(MTS)) == 10
     p2 = get_data_Rpv(MTS)[8]
+    radius2 = invertibility_radius(M, p2)
     solve!(
         MTS,
         mco,
         M,
         p2,
         StabilizedRetraction(),
-        ExactInvertibility(),
+        radius2,
         0
     )
     @test length(get_data_f(MTS)) == 221

--- a/test/invertibility.jl
+++ b/test/invertibility.jl
@@ -1,7 +1,7 @@
 @testset "Invertibility radii" begin
     M1 = Sphere(2)
     p1 = [0.0, 1.0, 0.0]
-    @test invertibility_radius(M1, p1) == π
+    @test isapprox(invertibility_radius(M1, p1), π)
 
     h(p) = norm(p)^2 - 1
     M2 = EqualityManifold(h, 1, 2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,4 +12,5 @@ using Manopt:
     include("StoppingCriteria.jl")
     include("TangentSolver.jl")
     include("invertibility.jl")
+    include("DFROSolver.jl")
 end


### PR DESCRIPTION
This is a first version of DFRO **without inequalities**. Those are completely ignored at the current stage.

More in-depth tests are needed to address some numerical instabilities. Typically, try to solve a simple problem for $$y=\vert x\vert$$ and see that Ipopt fails to project correctly.

Close #35 but doesn't take into account the discussion within the issue. Close #42 with a minimal print level functionality.